### PR TITLE
test: check diff for admin balance in fork tests

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -49,11 +49,11 @@ jobs:
       name: "Fork tests"
 
   notify-on-failure:
-    if: always()
+    if: failure()
+    needs: ["lint", "build", "test-integration", "test-fork"]
     runs-on: "ubuntu-latest"
     steps:
       - name: "Send Slack notification"
-        if: failure() # Runs only if a failure occurs in any previous job
         uses: "rtCamp/action-slack-notify@v2"
         env:
           SLACK_CHANNEL: "#ci-notifications"

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -32,7 +32,8 @@ jobs:
       name: "Utils tests"
 
   notify-on-failure:
-    if: always()
+    if: failure()
+    needs: ["lint", "build", "test-fork", "test-utils"]
     runs-on: "ubuntu-latest"
     steps:
       - name: "Send Slack notification"

--- a/tests/fork/merkle-campaign/MerkleInstant.t.sol
+++ b/tests/fork/merkle-campaign/MerkleInstant.t.sol
@@ -225,6 +225,6 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         merkleFactory.collectFees({ merkleBase: vars.merkleInstant });
 
         assertEq(address(vars.merkleInstant).balance, 0, "merkleInstant ETH balance");
-        assertEq(users.admin.balance - initialAdminBalance, fee, "admin ETH balance");
+        assertEq(users.admin.balance, initialAdminBalance + fee, "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleInstant.t.sol
+++ b/tests/fork/merkle-campaign/MerkleInstant.t.sol
@@ -145,6 +145,8 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
+        uint256 initialAdminBalance = users.admin.balance;
+
         assertFalse(vars.merkleInstant.hasClaimed(vars.indexes[params.posBeforeSort]));
 
         vars.leafToClaim = MerkleBuilder.computeLeaf(
@@ -223,6 +225,6 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         merkleFactory.collectFees({ merkleBase: vars.merkleInstant });
 
         assertEq(address(vars.merkleInstant).balance, 0, "merkleInstant ETH balance");
-        assertEq(users.admin.balance, fee, "admin ETH balance");
+        assertEq(users.admin.balance - initialAdminBalance, fee, "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -154,6 +154,8 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
+        uint256 initialAdminBalance = users.admin.balance;
+
         assertFalse(vars.merkleLL.hasClaimed(vars.indexes[params.posBeforeSort]));
 
         vars.leafToClaim = MerkleBuilder.computeLeaf(
@@ -252,6 +254,6 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         merkleFactory.collectFees({ merkleBase: vars.merkleLL });
 
         assertEq(address(vars.merkleLL).balance, 0, "merkleLL ETH balance");
-        assertEq(users.admin.balance, fee, "admin ETH balance");
+        assertEq(users.admin.balance - initialAdminBalance, fee, "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -254,6 +254,6 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         merkleFactory.collectFees({ merkleBase: vars.merkleLL });
 
         assertEq(address(vars.merkleLL).balance, 0, "merkleLL ETH balance");
-        assertEq(users.admin.balance - initialAdminBalance, fee, "admin ETH balance");
+        assertEq(users.admin.balance, initialAdminBalance + fee, "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLT.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLT.t.sol
@@ -153,6 +153,8 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
+        uint256 initialAdminBalance = users.admin.balance;
+
         assertFalse(vars.merkleLT.hasClaimed(vars.indexes[params.posBeforeSort]));
 
         vars.leafToClaim = MerkleBuilder.computeLeaf(
@@ -253,6 +255,6 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
         merkleFactory.collectFees({ merkleBase: vars.merkleLT });
 
         assertEq(address(vars.merkleLT).balance, 0, "merkleLT ETH balance");
-        assertEq(users.admin.balance, fee, "admin ETH balance");
+        assertEq(users.admin.balance - initialAdminBalance, fee, "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLT.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLT.t.sol
@@ -255,6 +255,6 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
         merkleFactory.collectFees({ merkleBase: vars.merkleLT });
 
         assertEq(address(vars.merkleLT).balance, 0, "merkleLT ETH balance");
-        assertEq(users.admin.balance - initialAdminBalance, fee, "admin ETH balance");
+        assertEq(users.admin.balance, initialAdminBalance + fee, "admin ETH balance");
     }
 }


### PR DESCRIPTION
This [fork CI failed](https://github.com/sablier-labs/airdrops/actions/runs/12218384157/job/34083834453) because foundry chose `users.admin` as one of the recipients. Thus, the following assertion failed:

```solidity
assertEq(users.admin.balance, fee, "admin ETH balance");
```

As a good practice, instead of comparing absolute balance, we should compare diff to avoid such scenarios (though highly unlikely). This PR fixes that.

Other than that, the failed CI did not send any notification on the Slack, so I figured out that the `notify-on-failure` has a different code than the one in [v2-core repo](https://github.com/sablier-labs/v2-core/blob/main/.github/workflows/ci-deep.yml#L78C1-L89C58). This PR fixed that as well.