### PR TITLE
perf: store shape and campaign name in storage as bytes32

### DIFF
--- a/src/SablierMerkleLL.sol
+++ b/src/SablierMerkleLL.sol
@@ -122,7 +122,7 @@ contract SablierMerkleLL is
                 cancelable: STREAM_CANCELABLE,
                 transferable: STREAM_TRANSFERABLE,
                 timestamps: timestamps,
-                shape: shape,
+                shape: string(abi.encodePacked(SHAPE)),
                 broker: Broker({ account: address(0), fee: ZERO })
             }),
             LockupLinear.UnlockAmounts({ start: _schedule.startAmount, cliff: _schedule.cliffAmount }),

--- a/src/SablierMerkleLT.sol
+++ b/src/SablierMerkleLT.sol
@@ -137,7 +137,7 @@ contract SablierMerkleLT is
                 cancelable: STREAM_CANCELABLE,
                 transferable: STREAM_TRANSFERABLE,
                 timestamps: Lockup.Timestamps({ start: startTime, end: endTime }),
-                shape: shape,
+                shape: string(abi.encodePacked(SHAPE)),
                 broker: Broker({ account: address(0), fee: ZERO })
             }),
             tranches

--- a/src/abstracts/SablierMerkleBase.sol
+++ b/src/abstracts/SablierMerkleBase.sol
@@ -24,6 +24,9 @@ abstract contract SablierMerkleBase is
                                   STATE VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
 
+    // The name of the campaign stored as bytes32.
+    bytes32 internal immutable CAMPAIGN_NAME;
+
     /// @inheritdoc ISablierMerkleBase
     uint40 public immutable override EXPIRATION;
 
@@ -36,17 +39,14 @@ abstract contract SablierMerkleBase is
     /// @inheritdoc ISablierMerkleBase
     bytes32 public immutable override MERKLE_ROOT;
 
+    // The shape of Lockup stream stored as bytes32.
+    bytes32 internal immutable SHAPE;
+
     /// @inheritdoc ISablierMerkleBase
     IERC20 public immutable override TOKEN;
 
     /// @inheritdoc ISablierMerkleBase
-    string public override campaignName;
-
-    /// @inheritdoc ISablierMerkleBase
     string public override ipfsCID;
-
-    /// @inheritdoc ISablierMerkleBase
-    string public override shape;
 
     /// @dev Packed booleans that record the history of claims.
     BitMaps.BitMap internal _claimedBitMap;
@@ -65,14 +65,19 @@ abstract contract SablierMerkleBase is
         FEE = fee;
         MERKLE_ROOT = params.merkleRoot;
         TOKEN = params.token;
-        campaignName = _truncateString(params.campaignName);
+        CAMPAIGN_NAME = bytes32(abi.encodePacked(params.campaignName));
         ipfsCID = params.ipfsCID;
-        shape = _truncateString(params.shape);
+        SHAPE = bytes32(abi.encodePacked(params.shape));
     }
 
     /*//////////////////////////////////////////////////////////////////////////
                            USER-FACING CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc ISablierMerkleBase
+    function campaignName() external view override returns (string memory) {
+        return string(abi.encodePacked(CAMPAIGN_NAME));
+    }
 
     /// @inheritdoc ISablierMerkleBase
     function getFirstClaimTime() external view override returns (uint40) {
@@ -87,6 +92,11 @@ abstract contract SablierMerkleBase is
     /// @inheritdoc ISablierMerkleBase
     function hasExpired() public view override returns (bool) {
         return EXPIRATION > 0 && EXPIRATION <= block.timestamp;
+    }
+
+    /// @inheritdoc ISablierMerkleBase
+    function shape() external view override returns (string memory) {
+        return string(abi.encodePacked(SHAPE));
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -184,15 +194,6 @@ abstract contract SablierMerkleBase is
     /// @dev The grace period is 7 days after the first claim.
     function _hasGracePeriodPassed() internal view returns (bool) {
         return _firstClaimTime > 0 && block.timestamp > _firstClaimTime + 7 days;
-    }
-
-    /// @notice Truncates a string to a maximum length of 32 bytes.
-    /// @dev If the string's length is 32 bytes or less, it is returned unchanged.
-    function _truncateString(string memory s) private pure returns (string memory) {
-        if (bytes(s).length > 32) {
-            return string(abi.encodePacked(bytes32(abi.encodePacked(s))));
-        }
-        return s;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/src/abstracts/SablierMerkleBase.sol
+++ b/src/abstracts/SablierMerkleBase.sol
@@ -24,7 +24,7 @@ abstract contract SablierMerkleBase is
                                   STATE VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
 
-    // The name of the campaign stored as bytes32.
+    /// @dev The name of the campaign stored as bytes32.
     bytes32 internal immutable CAMPAIGN_NAME;
 
     /// @inheritdoc ISablierMerkleBase
@@ -39,7 +39,7 @@ abstract contract SablierMerkleBase is
     /// @inheritdoc ISablierMerkleBase
     bytes32 public immutable override MERKLE_ROOT;
 
-    // The shape of Lockup stream stored as bytes32.
+    /// @dev The shape of Lockup stream stored as bytes32.
     bytes32 internal immutable SHAPE;
 
     /// @inheritdoc ISablierMerkleBase

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -11,7 +11,7 @@ library MerkleBase {
     /// @param initialAdmin The initial admin of the campaign.
     /// @param ipfsCID The content identifier for indexing the contract on IPFS.
     /// @param merkleRoot The Merkle root of the claim data.
-    /// @param campaignName The name of the campaign.
+    /// @param campaignName The name of the campaign. It is truncated if exceeding 32 bytes
     /// @param shape The shape of Lockup stream is used for differentiating between streams in the UI. It is truncated
     /// if exceeding 32 bytes.
     struct ConstructorParams {

--- a/tests/utils/Defaults.sol
+++ b/tests/utils/Defaults.sol
@@ -33,6 +33,7 @@ contract Defaults is Constants, Merkle {
     //////////////////////////////////////////////////////////////////////////*/
 
     uint256 public constant AGGREGATE_AMOUNT = CLAIM_AMOUNT * RECIPIENT_COUNT;
+    // Since Factory stores campaign name as bytes32, extra spaces are padded to it.
     string public constant CAMPAIGN_NAME = "Airdrop Campaign                ";
     bool public constant CANCELABLE = false;
     uint128 public constant CLAIM_AMOUNT = 10_000e18;
@@ -47,6 +48,7 @@ contract Defaults is Constants, Merkle {
     uint256[] public LEAVES = new uint256[](RECIPIENT_COUNT);
     uint256 public constant RECIPIENT_COUNT = 4;
     bytes32 public MERKLE_ROOT;
+    // Since Factory stores shape as bytes32, extra spaces are padded to it.
     string public constant SHAPE = "A custom stream shape           ";
     uint40 public immutable STREAM_START_TIME_NON_ZERO = JULY_1_2024 - 2 days;
     uint40 public immutable STREAM_START_TIME_ZERO = 0;

--- a/tests/utils/Defaults.sol
+++ b/tests/utils/Defaults.sol
@@ -33,7 +33,7 @@ contract Defaults is Constants, Merkle {
     //////////////////////////////////////////////////////////////////////////*/
 
     uint256 public constant AGGREGATE_AMOUNT = CLAIM_AMOUNT * RECIPIENT_COUNT;
-    string public constant CAMPAIGN_NAME = "Airdrop Campaign";
+    string public constant CAMPAIGN_NAME = "Airdrop Campaign                ";
     bool public constant CANCELABLE = false;
     uint128 public constant CLAIM_AMOUNT = 10_000e18;
     uint40 public immutable EXPIRATION;
@@ -47,7 +47,7 @@ contract Defaults is Constants, Merkle {
     uint256[] public LEAVES = new uint256[](RECIPIENT_COUNT);
     uint256 public constant RECIPIENT_COUNT = 4;
     bytes32 public MERKLE_ROOT;
-    string public constant SHAPE = "A custom stream shape";
+    string public constant SHAPE = "A custom stream shape           ";
     uint40 public immutable STREAM_START_TIME_NON_ZERO = JULY_1_2024 - 2 days;
     uint40 public immutable STREAM_START_TIME_ZERO = 0;
     uint64 public constant TOTAL_PERCENTAGE = uUNIT;


### PR DESCRIPTION
## Changelog
- Store campaign name and lockup shape as `bytes32` in the contract storage
- No change to the interface

## Motivation
@andreivladbrg noticed that the Factory contract size exceeded the limit even at just 50 runs. Upon further investigation, it became clear that storing values as strings was significantly increasing the bytecode size. By switching the storage variable type from `string` to `bytes32`, the contract size was reduced by 3,000.﻿ Its now 23,639 B which is well below the limit. 

## Trade-off
Since the String is first converted to `bytes32` and then back to the String during stream creation, it results in additional whitespace padding. For instance, "Airdrop Campaign" would ultimately be stored as `Airdrop Campaign                `. Most UIs, such as Etherscan's, are intelligent enough to trim these extra spaces.

One potential solution could involve storing the string length alongside the value, but this would introduce unnecessary complexity. In my opinion, this trade-off should be acceptable since the shape and campaign names are only intended for Sablier UI which can take care of it.

## Note
In the future, if needed, we can further reduce the size by 1000 bytes by using `bytes32` instead of `string` for the `campaignName` and `shape` fields in the input parameters of `ConstructorParams`.