### PR TITLE
test: use mainnet addresses in fork tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "prepare": "husky",
     "prettier:check": "prettier --check \"**/*.{json,md,yml}\"",
     "prettier:write": "prettier --write \"**/*.{json,md,yml}\"",
-    "test": "forge test",
-    "test:lite": "FOUNDRY_PROFILE=lite forge test",
+    "test": "forge test --nmt testFork",
+    "test:lite": "FOUNDRY_PROFILE=lite forge test --nmt testFork",
     "test:optimized": "bun run build:optimized && FOUNDRY_PROFILE=test-optimized forge test"
   }
 }

--- a/script/CreateMerkleInstant.s.sol
+++ b/script/CreateMerkleInstant.s.sol
@@ -10,7 +10,7 @@ import { BaseScript } from "./Base.s.sol";
 /// @dev Creates a dummy campaign to airdrop tokens instantly.
 contract CreateMerkleInstant is BaseScript {
     /// @dev Deploy via Forge.
-    function run() public virtual broadcast returns (ISablierMerkleInstant merkleInstant) {
+    function run() public broadcast returns (ISablierMerkleInstant merkleInstant) {
         ISablierMerkleFactory merkleFactory = ISablierMerkleFactory(0x71DD3Ca88E7564416E5C2E350090C12Bf8F6144a);
 
         // Prepare the constructor parameters.

--- a/script/CreateMerkleLL.s.sol
+++ b/script/CreateMerkleLL.s.sol
@@ -14,7 +14,7 @@ import { BaseScript } from "./Base.s.sol";
 /// @dev Creates a dummy campaign to airdrop tokens through Lockup Linear.
 contract CreateMerkleLL is BaseScript {
     /// @dev Deploy via Forge.
-    function run() public virtual broadcast returns (ISablierMerkleLL merkleLL) {
+    function run() public broadcast returns (ISablierMerkleLL merkleLL) {
         ISablierMerkleFactory merkleFactory = ISablierMerkleFactory(0x71DD3Ca88E7564416E5C2E350090C12Bf8F6144a);
 
         // Prepare the constructor parameters.

--- a/script/CreateMerkleLT.s.sol
+++ b/script/CreateMerkleLT.s.sol
@@ -14,7 +14,7 @@ import { BaseScript } from "./Base.s.sol";
 /// @dev Creates a dummy campaign to airdrop tokens through Lockup Tranched.
 contract CreateMerkleLT is BaseScript {
     /// @dev Deploy via Forge.
-    function run() public virtual broadcast returns (ISablierMerkleLT merkleLT) {
+    function run() public broadcast returns (ISablierMerkleLT merkleLT) {
         ISablierMerkleFactory merkleFactory = ISablierMerkleFactory(0x71DD3Ca88E7564416E5C2E350090C12Bf8F6144a);
 
         // Prepare the constructor parameters.

--- a/script/DeployDeterministicMerkleFactory.s.sol
+++ b/script/DeployDeterministicMerkleFactory.s.sol
@@ -10,7 +10,7 @@ import { BaseScript } from "./Base.s.sol";
 /// @dev Reverts if any contract has already been deployed.
 contract DeployDeterministicMerkleFactory is BaseScript {
     /// @dev Deploy via Forge.
-    function run() public virtual broadcast returns (SablierMerkleFactory merkleFactory) {
+    function run() public broadcast returns (SablierMerkleFactory merkleFactory) {
         address initialAdmin = adminMap[block.chainid];
         merkleFactory = new SablierMerkleFactory{ salt: SALT }(initialAdmin);
     }

--- a/script/DeployMerkleFactory.s.sol
+++ b/script/DeployMerkleFactory.s.sol
@@ -7,7 +7,7 @@ import { BaseScript } from "./Base.s.sol";
 
 contract DeployMerkleFactory is BaseScript {
     /// @dev Deploy via Forge.
-    function run() public virtual broadcast returns (SablierMerkleFactory merkleFactory) {
+    function run() public broadcast returns (SablierMerkleFactory merkleFactory) {
         address initialAdmin = adminMap[block.chainid];
         merkleFactory = new SablierMerkleFactory(initialAdmin);
     }

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -191,11 +191,12 @@ abstract contract Base_Test is Assertions, Constants, DeployOptimized, Modifiers
         view
         returns (address)
     {
-        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
-        baseParams.token = token_;
-        baseParams.expiration = expiration;
-        baseParams.initialAdmin = campaignOwner;
-        baseParams.merkleRoot = merkleRoot;
+        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams({
+            campaignOwner: campaignOwner,
+            token_: token_,
+            expiration: expiration,
+            merkleRoot: merkleRoot
+        });
 
         bytes32 salt = keccak256(abi.encodePacked(campaignCreator, abi.encode(baseParams)));
         bytes32 creationBytecodeHash =
@@ -218,11 +219,12 @@ abstract contract Base_Test is Assertions, Constants, DeployOptimized, Modifiers
         view
         returns (address)
     {
-        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
-        baseParams.token = token_;
-        baseParams.expiration = expiration;
-        baseParams.initialAdmin = campaignOwner;
-        baseParams.merkleRoot = merkleRoot;
+        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams({
+            campaignOwner: campaignOwner,
+            token_: token_,
+            expiration: expiration,
+            merkleRoot: merkleRoot
+        });
         bytes32 salt = keccak256(
             abi.encodePacked(
                 campaignCreator,
@@ -253,11 +255,12 @@ abstract contract Base_Test is Assertions, Constants, DeployOptimized, Modifiers
         view
         returns (address)
     {
-        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
-        baseParams.token = token_;
-        baseParams.expiration = expiration;
-        baseParams.initialAdmin = campaignOwner;
-        baseParams.merkleRoot = merkleRoot;
+        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams({
+            campaignOwner: campaignOwner,
+            token_: token_,
+            expiration: expiration,
+            merkleRoot: merkleRoot
+        });
         bytes32 salt = keccak256(
             abi.encodePacked(
                 campaignCreator,

--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.22 <0.9.0;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 import { Merkle } from "murky/src/Merkle.sol";
+import { ISablierMerkleFactory } from "src/interfaces/ISablierMerkleFactory.sol";
 
 import { Base_Test } from "../Base.t.sol";
 
@@ -29,12 +30,10 @@ abstract contract Fork_Test is Base_Test, Merkle {
 
     function setUp() public virtual override {
         // Fork Ethereum Mainnet at a specific block number.
-        vm.createSelectFork({ blockNumber: 21_745_237, urlOrAlias: "mainnet" });
+        vm.createSelectFork({ blockNumber: 21_719_244, urlOrAlias: "mainnet" });
 
-        // Set up the parent test contract.
-        Base_Test.setUp();
-
-        // Load the pre-deployed external dependencies.
+        // Load deployed addresses from Ethereum mainnet.
+        merkleFactory = ISablierMerkleFactory(0x71DD3Ca88E7564416E5C2E350090C12Bf8F6144a);
         lockup = ISablierLockup(0x7C01AA3783577E15fD7e272443D44B92d5b21056);
     }
 }

--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -16,6 +16,7 @@ abstract contract Fork_Test is Base_Test, Merkle {
     //////////////////////////////////////////////////////////////////////////*/
 
     IERC20 internal immutable FORK_TOKEN;
+    address internal factoryAdmin;
 
     /*//////////////////////////////////////////////////////////////////////////
                                     CONSTRUCTOR
@@ -37,11 +38,14 @@ abstract contract Fork_Test is Base_Test, Merkle {
         merkleFactory = ISablierMerkleFactory(0x71DD3Ca88E7564416E5C2E350090C12Bf8F6144a);
         lockup = ISablierLockup(0x7C01AA3783577E15fD7e272443D44B92d5b21056);
 
+        // Load the factory admin from mainnet.
+        factoryAdmin = merkleFactory.admin();
+
         // Initialize the defaults contract.
         defaults = new Defaults();
 
         // Set the default fee for campaign.
-        resetPrank({ msgSender: merkleFactory.admin() });
+        resetPrank({ msgSender: factoryAdmin });
         merkleFactory.setDefaultFee(defaults.FEE());
     }
 }

--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -7,6 +7,7 @@ import { Merkle } from "murky/src/Merkle.sol";
 import { ISablierMerkleFactory } from "src/interfaces/ISablierMerkleFactory.sol";
 
 import { Base_Test } from "../Base.t.sol";
+import { Defaults } from "../utils/Defaults.sol";
 
 /// @notice Common logic needed by all fork tests.
 abstract contract Fork_Test is Base_Test, Merkle {
@@ -35,5 +36,12 @@ abstract contract Fork_Test is Base_Test, Merkle {
         // Load deployed addresses from Ethereum mainnet.
         merkleFactory = ISablierMerkleFactory(0x71DD3Ca88E7564416E5C2E350090C12Bf8F6144a);
         lockup = ISablierLockup(0x7C01AA3783577E15fD7e272443D44B92d5b21056);
+
+        // Initialize the defaults contract.
+        defaults = new Defaults();
+
+        // Set the default fee for campaign.
+        resetPrank({ msgSender: merkleFactory.admin() });
+        merkleFactory.setDefaultFee(defaults.FEE());
     }
 }

--- a/tests/fork/merkle-campaign/MerkleInstant.t.sol
+++ b/tests/fork/merkle-campaign/MerkleInstant.t.sol
@@ -37,6 +37,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         MerkleBase.ConstructorParams baseParams;
         uint128 clawbackAmount;
         address expectedMerkleInstant;
+        address factoryAdmin;
         uint256[] indexes;
         uint256 leafPos;
         uint256 leafToClaim;
@@ -51,7 +52,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
     uint256[] public leaves;
 
     function testForkFuzz_MerkleInstant(Params memory params) external {
-        vm.assume(params.campaignOwner != address(0) && params.campaignOwner != users.campaignOwner);
+        vm.assume(params.campaignOwner != address(0));
         vm.assume(params.leafData.length > 0);
         assumeNoBlacklisted({ token: address(FORK_TOKEN), addr: params.campaignOwner });
         params.posBeforeSort = _bound(params.posBeforeSort, 0, params.leafData.length - 1);
@@ -68,6 +69,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         Vars memory vars;
         vars.recipientCount = params.leafData.length;
         vars.amounts = new uint128[](vars.recipientCount);
+        vars.factoryAdmin = merkleFactory.admin();
         vars.indexes = new uint256[](vars.recipientCount);
         vars.recipients = new address[](vars.recipientCount);
         for (uint256 i = 0; i < vars.recipientCount; ++i) {
@@ -80,7 +82,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
             // Avoid zero recipient addresses.
             uint256 boundedRecipientSeed = _bound(params.leafData[i].recipientSeed, 1, type(uint160).max);
             // Avoid recipient to be the protocol admin.
-            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != users.admin
+            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != vars.factoryAdmin
                 ? address(uint160(boundedRecipientSeed))
                 : address(uint160(boundedRecipientSeed) + 1);
         }
@@ -109,8 +111,8 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         vars.baseParams = defaults.baseParams({
             campaignOwner: params.campaignOwner,
             token_: FORK_TOKEN,
-            merkleRoot: vars.merkleRoot,
-            expiration: params.expiration
+            expiration: params.expiration,
+            merkleRoot: vars.merkleRoot
         });
 
         vm.expectEmit({ emitter: address(merkleFactory) });
@@ -146,7 +148,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
-        uint256 initialAdminBalance = users.admin.balance;
+        uint256 initialAdminBalance = vars.factoryAdmin.balance;
 
         assertFalse(vars.merkleInstant.hasClaimed(vars.indexes[params.posBeforeSort]));
 
@@ -223,13 +225,13 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
 
         vm.expectEmit({ emitter: address(merkleFactory) });
         emit ISablierMerkleFactory.CollectFees({
-            admin: users.admin,
+            admin: vars.factoryAdmin,
             merkleBase: vars.merkleInstant,
             feeAmount: defaults.FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleInstant });
 
         assertEq(address(vars.merkleInstant).balance, 0, "merkleInstant ETH balance");
-        assertEq(users.admin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(vars.factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleInstant.t.sol
+++ b/tests/fork/merkle-campaign/MerkleInstant.t.sol
@@ -37,7 +37,6 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         MerkleBase.ConstructorParams baseParams;
         uint128 clawbackAmount;
         address expectedMerkleInstant;
-        address factoryAdmin;
         uint256[] indexes;
         uint256 leafPos;
         uint256 leafToClaim;
@@ -69,7 +68,6 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         Vars memory vars;
         vars.recipientCount = params.leafData.length;
         vars.amounts = new uint128[](vars.recipientCount);
-        vars.factoryAdmin = merkleFactory.admin();
         vars.indexes = new uint256[](vars.recipientCount);
         vars.recipients = new address[](vars.recipientCount);
         for (uint256 i = 0; i < vars.recipientCount; ++i) {
@@ -82,7 +80,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
             // Avoid zero recipient addresses.
             uint256 boundedRecipientSeed = _bound(params.leafData[i].recipientSeed, 1, type(uint160).max);
             // Avoid recipient to be the protocol admin.
-            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != vars.factoryAdmin
+            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != factoryAdmin
                 ? address(uint160(boundedRecipientSeed))
                 : address(uint160(boundedRecipientSeed) + 1);
         }
@@ -148,7 +146,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
-        uint256 initialAdminBalance = vars.factoryAdmin.balance;
+        uint256 initialAdminBalance = factoryAdmin.balance;
 
         assertFalse(vars.merkleInstant.hasClaimed(vars.indexes[params.posBeforeSort]));
 
@@ -225,13 +223,13 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
 
         vm.expectEmit({ emitter: address(merkleFactory) });
         emit ISablierMerkleFactory.CollectFees({
-            admin: vars.factoryAdmin,
+            admin: factoryAdmin,
             merkleBase: vars.merkleInstant,
             feeAmount: defaults.FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleInstant });
 
         assertEq(address(vars.merkleInstant).balance, 0, "merkleInstant ETH balance");
-        assertEq(vars.factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -39,7 +39,6 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         uint128 clawbackAmount;
         address expectedLL;
         uint256 expectedStreamId;
-        address factoryAdmin;
         uint256[] indexes;
         uint256 leafPos;
         uint256 leafToClaim;
@@ -72,7 +71,6 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         Vars memory vars;
         vars.recipientCount = params.leafData.length;
         vars.amounts = new uint128[](vars.recipientCount);
-        vars.factoryAdmin = merkleFactory.admin();
         vars.indexes = new uint256[](vars.recipientCount);
         vars.recipients = new address[](vars.recipientCount);
         for (uint256 i = 0; i < vars.recipientCount; ++i) {
@@ -85,7 +83,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
             // Avoid zero recipient addresses.
             uint256 boundedRecipientSeed = _bound(params.leafData[i].recipientSeed, 1, type(uint160).max);
             // Avoid recipient to be the protocol admin.
-            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != vars.factoryAdmin
+            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != factoryAdmin
                 ? address(uint160(boundedRecipientSeed))
                 : address(uint160(boundedRecipientSeed) + 1);
         }
@@ -155,7 +153,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
-        uint256 initialAdminBalance = vars.factoryAdmin.balance;
+        uint256 initialAdminBalance = factoryAdmin.balance;
 
         assertFalse(vars.merkleLL.hasClaimed(vars.indexes[params.posBeforeSort]));
 
@@ -265,13 +263,13 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
 
         vm.expectEmit({ emitter: address(merkleFactory) });
         emit ISablierMerkleFactory.CollectFees({
-            admin: vars.factoryAdmin,
+            admin: factoryAdmin,
             merkleBase: vars.merkleLL,
             feeAmount: defaults.FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleLL });
 
         assertEq(address(vars.merkleLL).balance, 0, "merkleLL ETH balance");
-        assertEq(vars.factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -39,6 +39,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         uint128 clawbackAmount;
         address expectedLL;
         uint256 expectedStreamId;
+        address factoryAdmin;
         uint256[] indexes;
         uint256 leafPos;
         uint256 leafToClaim;
@@ -54,7 +55,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
     uint256[] public leaves;
 
     function testForkFuzz_MerkleLL(Params memory params) external {
-        vm.assume(params.campaignOwner != address(0) && params.campaignOwner != users.campaignOwner);
+        vm.assume(params.campaignOwner != address(0));
         vm.assume(params.leafData.length > 0);
         assumeNoBlacklisted({ token: address(FORK_TOKEN), addr: params.campaignOwner });
         params.posBeforeSort = _bound(params.posBeforeSort, 0, params.leafData.length - 1);
@@ -71,6 +72,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         Vars memory vars;
         vars.recipientCount = params.leafData.length;
         vars.amounts = new uint128[](vars.recipientCount);
+        vars.factoryAdmin = merkleFactory.admin();
         vars.indexes = new uint256[](vars.recipientCount);
         vars.recipients = new address[](vars.recipientCount);
         for (uint256 i = 0; i < vars.recipientCount; ++i) {
@@ -83,7 +85,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
             // Avoid zero recipient addresses.
             uint256 boundedRecipientSeed = _bound(params.leafData[i].recipientSeed, 1, type(uint160).max);
             // Avoid recipient to be the protocol admin.
-            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != users.admin
+            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != vars.factoryAdmin
                 ? address(uint160(boundedRecipientSeed))
                 : address(uint160(boundedRecipientSeed) + 1);
         }
@@ -112,8 +114,8 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         vars.baseParams = defaults.baseParams({
             campaignOwner: params.campaignOwner,
             token_: FORK_TOKEN,
-            merkleRoot: vars.merkleRoot,
-            expiration: params.expiration
+            expiration: params.expiration,
+            merkleRoot: vars.merkleRoot
         });
 
         vm.expectEmit({ emitter: address(merkleFactory) });
@@ -153,7 +155,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
-        uint256 initialAdminBalance = users.admin.balance;
+        uint256 initialAdminBalance = vars.factoryAdmin.balance;
 
         assertFalse(vars.merkleLL.hasClaimed(vars.indexes[params.posBeforeSort]));
 
@@ -263,13 +265,13 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
 
         vm.expectEmit({ emitter: address(merkleFactory) });
         emit ISablierMerkleFactory.CollectFees({
-            admin: users.admin,
+            admin: vars.factoryAdmin,
             merkleBase: vars.merkleLL,
             feeAmount: defaults.FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleLL });
 
         assertEq(address(vars.merkleLL).balance, 0, "merkleLL ETH balance");
-        assertEq(users.admin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(vars.factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLT.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLT.t.sol
@@ -38,7 +38,6 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
         uint128 clawbackAmount;
         address expectedLT;
         uint256 expectedStreamId;
-        address factoryAdmin;
         uint256[] indexes;
         uint256 leafPos;
         uint256 leafToClaim;
@@ -70,7 +69,6 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
         Vars memory vars;
         vars.recipientCount = params.leafData.length;
         vars.amounts = new uint128[](vars.recipientCount);
-        vars.factoryAdmin = merkleFactory.admin();
         vars.indexes = new uint256[](vars.recipientCount);
         vars.recipients = new address[](vars.recipientCount);
         for (uint256 i = 0; i < vars.recipientCount; ++i) {
@@ -83,7 +81,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             // Avoid zero recipient addresses.
             uint256 boundedRecipientSeed = _bound(params.leafData[i].recipientSeed, 1, type(uint160).max);
             // Avoid recipient to be the protocol admin.
-            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != vars.factoryAdmin
+            vars.recipients[i] = address(uint160(boundedRecipientSeed)) != factoryAdmin
                 ? address(uint160(boundedRecipientSeed))
                 : address(uint160(boundedRecipientSeed) + 1);
         }
@@ -156,7 +154,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
         resetPrank({ msgSender: vars.recipients[params.posBeforeSort] });
         vm.deal(vars.recipients[params.posBeforeSort], 1 ether);
 
-        uint256 initialAdminBalance = vars.factoryAdmin.balance;
+        uint256 initialAdminBalance = factoryAdmin.balance;
 
         assertFalse(vars.merkleLT.hasClaimed(vars.indexes[params.posBeforeSort]));
 
@@ -255,13 +253,13 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
 
         vm.expectEmit({ emitter: address(merkleFactory) });
         emit ISablierMerkleFactory.CollectFees({
-            admin: vars.factoryAdmin,
+            admin: factoryAdmin,
             merkleBase: vars.merkleLT,
             feeAmount: defaults.FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleLT });
 
         assertEq(address(vars.merkleLT).balance, 0, "merkleLT ETH balance");
-        assertEq(vars.factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
     }
 }


### PR DESCRIPTION
### Changelog
- Change visibility of `_run` to `internal` and remove unneeded `virtual` from `run`
- Use mainnet address in fork tests
- Use actual Factory's admin in fork tests
- Add `--nmt testFork` in `test` and `test:lite` scripts. Use optimized profile to run fork tests locally

@andreivladbrg, it took half a day to figure out why the fork tests were failing locally. It is because the deployed contract is optimized so the default profiles cant make fork tests pass on deployed factory due to `CREATE2`.