### PR TITLE
refactor: rename defaultFee to minimumFee

### DIFF
--- a/src/SablierMerkleFactory.sol
+++ b/src/SablierMerkleFactory.sol
@@ -44,7 +44,7 @@ contract SablierMerkleFactory is
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ISablierMerkleFactory
-    uint256 public override defaultFee;
+    uint256 public override minimumFee;
 
     /// @dev A mapping of custom fees mapped by campaign creator addresses.
     mapping(address campaignCreator => MerkleFactory.CustomFee customFee) private _customFees;
@@ -211,19 +211,19 @@ contract SablierMerkleFactory is
     }
 
     /// @inheritdoc ISablierMerkleFactory
-    function setDefaultFee(uint256 defaultFee_) external override onlyAdmin {
-        // Effect: update the default fee.
-        defaultFee = defaultFee_;
+    function setMinimumFee(uint256 newFee) external override onlyAdmin {
+        // Effect: update the minimum fee.
+        minimumFee = newFee;
 
-        emit SetDefaultFee(msg.sender, defaultFee_);
+        emit SetMinimumFee(msg.sender, newFee);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
                             PRIVATE CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Retrieves the fee for the provided campaign creator, using the default fee if no custom fee is set.
+    /// @notice Retrieves the fee for the provided campaign creator, using the minimum fee if no custom fee is set.
     function _getFee(address campaignCreator) private view returns (uint256) {
-        return _customFees[campaignCreator].enabled ? _customFees[campaignCreator].fee : defaultFee;
+        return _customFees[campaignCreator].enabled ? _customFees[campaignCreator].fee : minimumFee;
     }
 }

--- a/src/SablierMerkleFactory.sol
+++ b/src/SablierMerkleFactory.sol
@@ -215,7 +215,7 @@ contract SablierMerkleFactory is
         // Effect: update the minimum fee.
         minimumFee = newFee;
 
-        emit SetMinimumFee(msg.sender, newFee);
+        emit SetMinimumFee({ admin: msg.sender, minimumFee: newFee });
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/src/abstracts/SablierMerkleBase.sol
+++ b/src/abstracts/SablierMerkleBase.sol
@@ -31,10 +31,10 @@ abstract contract SablierMerkleBase is
     address public immutable override FACTORY;
 
     /// @inheritdoc ISablierMerkleBase
-    uint256 public immutable override FEE;
+    bytes32 public immutable override MERKLE_ROOT;
 
     /// @inheritdoc ISablierMerkleBase
-    bytes32 public immutable override MERKLE_ROOT;
+    uint256 public immutable override MINIMUM_FEE;
 
     /// @inheritdoc ISablierMerkleBase
     IERC20 public immutable override TOKEN;
@@ -70,7 +70,7 @@ abstract contract SablierMerkleBase is
         campaignName = _campaignName;
         EXPIRATION = expiration;
         FACTORY = msg.sender;
-        FEE = ISablierMerkleFactory(FACTORY).getFee(campaignCreator);
+        MINIMUM_FEE = ISablierMerkleFactory(FACTORY).getFee(campaignCreator);
         MERKLE_ROOT = merkleRoot;
         TOKEN = token;
         ipfsCID = _ipfsCID;
@@ -115,9 +115,9 @@ abstract contract SablierMerkleBase is
             revert Errors.SablierMerkleBase_CampaignExpired({ blockTimestamp: block.timestamp, expiration: EXPIRATION });
         }
 
-        // Check: `msg.value` is not less than the fee.
-        if (msg.value < FEE) {
-            revert Errors.SablierMerkleBase_InsufficientFeePayment(msg.value, FEE);
+        // Check: `msg.value` is not less than the minimum fee.
+        if (msg.value < MINIMUM_FEE) {
+            revert Errors.SablierMerkleBase_InsufficientFeePayment(msg.value, MINIMUM_FEE);
         }
 
         // Check: the index has not been claimed.

--- a/src/interfaces/ISablierMerkleBase.sol
+++ b/src/interfaces/ISablierMerkleBase.sol
@@ -25,13 +25,13 @@ interface ISablierMerkleBase is IAdminable {
     /// @notice Retrieves the address of the factory contract.
     function FACTORY() external view returns (address);
 
-    /// @notice Retrieves the minimum fee required to claim the airdrop, which is paid in the native token of the chain,
-    /// e.g. ETH for Ethereum Mainnet.
-    function FEE() external view returns (uint256);
-
     /// @notice The root of the Merkle tree used to validate the proofs of inclusion.
     /// @dev This is an immutable state variable.
     function MERKLE_ROOT() external returns (bytes32);
+
+    /// @notice Retrieves the minimum fee required to claim the airdrop, which is paid in the native token of the chain,
+    /// e.g. ETH for Ethereum Mainnet.
+    function MINIMUM_FEE() external view returns (uint256);
 
     /// @notice The ERC-20 token to distribute.
     /// @dev This is an immutable state variable.
@@ -67,7 +67,7 @@ interface ISablierMerkleBase is IAdminable {
     /// - The campaign must not have expired.
     /// - The stream must not have been claimed already.
     /// - The Merkle proof must be valid.
-    /// - The `msg.value` must not be less than `FEE`.
+    /// - The `msg.value` must not be less than `MINIMUM_FEE`.
     ///
     /// @param index The index of the recipient in the Merkle tree.
     /// @param recipient The address of the airdrop recipient.

--- a/src/interfaces/ISablierMerkleFactory.sol
+++ b/src/interfaces/ISablierMerkleFactory.sol
@@ -52,29 +52,25 @@ interface ISablierMerkleFactory is IAdminable {
         uint256 fee
     );
 
-    /// @notice Emitted when the admin resets the custom fee for the provided campaign creator to the default fee.
+    /// @notice Emitted when the admin resets the custom fee for the provided campaign creator to the minimum fee.
     event ResetCustomFee(address indexed admin, address indexed campaignCreator);
 
     /// @notice Emitted when the admin sets a custom fee for the provided campaign creator.
     event SetCustomFee(address indexed admin, address indexed campaignCreator, uint256 customFee);
 
-    /// @notice Emitted when the default fee is set by the admin.
-    event SetDefaultFee(address indexed admin, uint256 defaultFee);
+    /// @notice Emitted when the minimum fee is set by the admin.
+    event SetMinimumFee(address indexed admin, uint256 minimumFee);
 
     /*//////////////////////////////////////////////////////////////////////////
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
-
-    /// @notice Retrieves the default fee charged for claiming an airdrop.
-    /// @dev The fee is denominated in the native token of the chain, e.g., ETH for Ethereum Mainnet.
-    function defaultFee() external view returns (uint256);
 
     /// @notice Retrieves the custom fee struct for the provided campaign creator.
     /// @dev The fee is denominated in the native token of the chain, e.g., ETH for Ethereum Mainnet.
     /// @param campaignCreator The address of the campaign creator.
     function getCustomFee(address campaignCreator) external view returns (MerkleFactory.CustomFee memory);
 
-    /// @notice Retrieves the fee for the provided campaign creator, using the default fee if no custom fee is set.
+    /// @notice Retrieves the fee for the provided campaign creator, using the minimum fee if no custom fee is set.
     /// @dev The fee is denominated in the native token of the chain, e.g., ETH for Ethereum Mainnet.
     /// @param campaignCreator The address of the campaign creator.
     function getFee(address campaignCreator) external view returns (uint256);
@@ -87,6 +83,10 @@ interface ISablierMerkleFactory is IAdminable {
         external
         pure
         returns (bool result);
+
+    /// @notice Retrieves the minimum fee charged for claiming an airdrop.
+    /// @dev The fee is denominated in the native token of the chain, e.g., ETH for Ethereum Mainnet.
+    function minimumFee() external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////////////////
                                NON-CONSTANT FUNCTIONS
@@ -147,7 +147,7 @@ interface ISablierMerkleFactory is IAdminable {
     ///
     /// Notes:
     /// - The MerkleLT contract is created with CREATE2.
-    /// - The immutable fee will be set to the default value unless a custom fee is set.
+    /// - The immutable fee will be set to the minimum value unless a custom fee is set.
     ///
     /// @param params Struct encapsulating the input parameters, which are documented in {DataTypes}.
     /// @param aggregateAmount The total amount of ERC-20 tokens to be distributed to all recipients.
@@ -161,11 +161,11 @@ interface ISablierMerkleFactory is IAdminable {
         external
         returns (ISablierMerkleLT merkleLT);
 
-    /// @notice Resets the custom fee for the provided campaign creator to the default fee.
+    /// @notice Resets the custom fee for the provided campaign creator to the minimum fee.
     /// @dev Emits a {ResetCustomFee} event.
     ///
     /// Notes:
-    /// - The default fee will only be applied to future campaigns.
+    /// - The minimum fee will only be applied to future campaigns.
     ///
     /// Requirements:
     /// - `msg.sender` must be the admin.
@@ -186,16 +186,16 @@ interface ISablierMerkleFactory is IAdminable {
     /// @param newFee The new fee to be set.
     function setCustomFee(address campaignCreator, uint256 newFee) external;
 
-    /// @notice Sets the default fee to be applied when claiming airdrops.
-    /// @dev Emits a {SetDefaultFee} event.
+    /// @notice Sets the minimum fee to be applied when claiming airdrops.
+    /// @dev Emits a {SetMinimumFee} event.
     ///
     /// Notes:
-    /// - The new default fee will only be applied to the future campaigns and will not affect the ones already
+    /// - The new minimum fee will only be applied to the future campaigns and will not affect the ones already
     /// deployed.
     ///
     /// Requirements:
     /// - `msg.sender` must be the admin.
     ///
-    /// @param defaultFee The new default fee to be set.
-    function setDefaultFee(uint256 defaultFee) external;
+    /// @param minimumFee The new minimum fee to be set.
+    function setMinimumFee(uint256 minimumFee) external;
 }

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -7,7 +7,7 @@ import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.so
 
 library MerkleFactory {
     /// @notice Struct encapsulating the custom fee details for a given campaign creator.
-    /// @param enabled Whether the fee is enabled. If false, the default fee will be applied for campaigns created by
+    /// @param enabled Whether the fee is enabled. If false, the minimum fee will be applied for campaigns created by
     /// the given creator.
     /// @param fee The fee amount.
     struct CustomFee {

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -68,8 +68,8 @@ abstract contract Base_Test is Assertions, Constants, DeployOptimized, Modifiers
         // Deploy the Merkle Factory.
         deployMerkleFactoryConditionally();
 
-        // Set the default fee on the Merkle factory.
-        merkleFactory.setDefaultFee(defaults.FEE());
+        // Set the minimum fee on the Merkle factory.
+        merkleFactory.setMinimumFee(defaults.MINIMUM_FEE());
 
         // Create users for testing.
         users.campaignOwner = createUser("CampaignOwner");

--- a/tests/fork/Fork.t.sol
+++ b/tests/fork/Fork.t.sol
@@ -44,8 +44,8 @@ abstract contract Fork_Test is Base_Test, Merkle {
         // Initialize the defaults contract.
         defaults = new Defaults();
 
-        // Set the default fee for campaign.
+        // Set the minimum fee for campaign.
         resetPrank({ msgSender: factoryAdmin });
-        merkleFactory.setDefaultFee(defaults.FEE());
+        merkleFactory.setMinimumFee(defaults.MINIMUM_FEE());
     }
 }

--- a/tests/fork/merkle-campaign/MerkleInstant.t.sol
+++ b/tests/fork/merkle-campaign/MerkleInstant.t.sol
@@ -124,7 +124,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
             params: vars.params,
             aggregateAmount: vars.aggregateAmount,
             recipientCount: vars.recipientCount,
-            fee: defaults.FEE()
+            fee: defaults.MINIMUM_FEE()
         });
 
         vars.merkleInstant = merkleFactory.createMerkleInstant(vars.params, vars.aggregateAmount, vars.recipientCount);
@@ -175,7 +175,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
 
         expectCallToClaimWithData({
             merkleLockup: address(vars.merkleInstant),
-            fee: defaults.FEE(),
+            fee: defaults.MINIMUM_FEE(),
             index: vars.indexes[params.posBeforeSort],
             recipient: vars.recipients[params.posBeforeSort],
             amount: vars.amounts[params.posBeforeSort],
@@ -188,7 +188,7 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
             value: vars.amounts[params.posBeforeSort]
         });
 
-        vars.merkleInstant.claim{ value: defaults.FEE() }({
+        vars.merkleInstant.claim{ value: defaults.MINIMUM_FEE() }({
             index: vars.indexes[params.posBeforeSort],
             recipient: vars.recipients[params.posBeforeSort],
             amount: vars.amounts[params.posBeforeSort],
@@ -226,11 +226,11 @@ abstract contract MerkleInstant_Fork_Test is Fork_Test {
         emit ISablierMerkleFactory.CollectFees({
             admin: factoryAdmin,
             merkleBase: vars.merkleInstant,
-            feeAmount: defaults.FEE()
+            feeAmount: defaults.MINIMUM_FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleInstant });
 
         assertEq(address(vars.merkleInstant).balance, 0, "merkleInstant ETH balance");
-        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.MINIMUM_FEE(), "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -130,7 +130,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
             params: vars.params,
             aggregateAmount: vars.aggregateAmount,
             recipientCount: vars.recipientCount,
-            fee: defaults.FEE()
+            fee: defaults.MINIMUM_FEE()
         });
 
         vars.merkleLL = merkleFactory.createMerkleLL(vars.params, vars.aggregateAmount, vars.recipientCount);
@@ -180,14 +180,14 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
 
         expectCallToClaimWithData({
             merkleLockup: address(vars.merkleLL),
-            fee: defaults.FEE(),
+            fee: defaults.MINIMUM_FEE(),
             index: vars.indexes[params.posBeforeSort],
             recipient: vars.recipients[params.posBeforeSort],
             amount: vars.amounts[params.posBeforeSort],
             merkleProof: vars.merkleProof
         });
 
-        vars.merkleLL.claim{ value: defaults.FEE() }({
+        vars.merkleLL.claim{ value: defaults.MINIMUM_FEE() }({
             index: vars.indexes[params.posBeforeSort],
             recipient: vars.recipients[params.posBeforeSort],
             amount: vars.amounts[params.posBeforeSort],
@@ -261,11 +261,11 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
         emit ISablierMerkleFactory.CollectFees({
             admin: factoryAdmin,
             merkleBase: vars.merkleLL,
-            feeAmount: defaults.FEE()
+            feeAmount: defaults.MINIMUM_FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleLL });
 
         assertEq(address(vars.merkleLL).balance, 0, "merkleLL ETH balance");
-        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.MINIMUM_FEE(), "admin ETH balance");
     }
 }

--- a/tests/fork/merkle-campaign/MerkleLT.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLT.t.sol
@@ -129,7 +129,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             aggregateAmount: vars.aggregateAmount,
             recipientCount: vars.recipientCount,
             totalDuration: defaults.TOTAL_DURATION(),
-            fee: defaults.FEE()
+            fee: defaults.MINIMUM_FEE()
         });
 
         vars.merkleLT = merkleFactory.createMerkleLT(vars.params, vars.aggregateAmount, vars.recipientCount);
@@ -178,14 +178,14 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
 
         expectCallToClaimWithData({
             merkleLockup: address(vars.merkleLT),
-            fee: defaults.FEE(),
+            fee: defaults.MINIMUM_FEE(),
             index: vars.indexes[params.posBeforeSort],
             recipient: vars.recipients[params.posBeforeSort],
             amount: vars.amounts[params.posBeforeSort],
             merkleProof: vars.merkleProof
         });
 
-        vars.merkleLT.claim{ value: defaults.FEE() }({
+        vars.merkleLT.claim{ value: defaults.MINIMUM_FEE() }({
             index: vars.indexes[params.posBeforeSort],
             recipient: vars.recipients[params.posBeforeSort],
             amount: vars.amounts[params.posBeforeSort],
@@ -249,11 +249,11 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
         emit ISablierMerkleFactory.CollectFees({
             admin: factoryAdmin,
             merkleBase: vars.merkleLT,
-            feeAmount: defaults.FEE()
+            feeAmount: defaults.MINIMUM_FEE()
         });
         merkleFactory.collectFees({ merkleBase: vars.merkleLT });
 
         assertEq(address(vars.merkleLT).balance, 0, "merkleLT ETH balance");
-        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(factoryAdmin.balance, initialAdminBalance + defaults.MINIMUM_FEE(), "admin ETH balance");
     }
 }

--- a/tests/integration/Integration.t.sol
+++ b/tests/integration/Integration.t.sol
@@ -53,7 +53,7 @@ contract Integration_Test is Base_Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     function claim() internal {
-        merkleBase.claim{ value: defaults.FEE() }({
+        merkleBase.claim{ value: defaults.MINIMUM_FEE() }({
             index: defaults.INDEX1(),
             recipient: users.recipient1,
             amount: defaults.CLAIM_AMOUNT(),

--- a/tests/integration/concrete/factory/collect-fees/collectFees.t.sol
+++ b/tests/integration/concrete/factory/collect-fees/collectFees.t.sol
@@ -68,7 +68,11 @@ contract CollectFees_Integration_Test is Integration_Test {
 
         // It should emit a {CollectFees} event.
         vm.expectEmit({ emitter: address(merkleFactory) });
-        emit ISablierMerkleFactory.CollectFees({ admin: admin, merkleBase: merkleBase, feeAmount: defaults.FEE() });
+        emit ISablierMerkleFactory.CollectFees({
+            admin: admin,
+            merkleBase: merkleBase,
+            feeAmount: defaults.MINIMUM_FEE()
+        });
 
         // Make Alice the caller.
         resetPrank({ msgSender: users.eve });
@@ -79,6 +83,6 @@ contract CollectFees_Integration_Test is Integration_Test {
         assertEq(address(merkleBase).balance, 0, "merkle lockup ETH balance");
 
         // It should transfer fee to the factory admin.
-        assertEq(admin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(admin.balance, initialAdminBalance + defaults.MINIMUM_FEE(), "admin ETH balance");
     }
 }

--- a/tests/integration/concrete/factory/constructor.t.sol
+++ b/tests/integration/concrete/factory/constructor.t.sol
@@ -12,7 +12,7 @@ contract Constructor_MerkleFactory_Integration_Test is Integration_Test {
         address actualAdmin = constructedFactory.admin();
         assertEq(actualAdmin, users.admin, "factory admin");
 
-        uint256 actualDefaultFee = constructedFactory.defaultFee();
-        assertEq(actualDefaultFee, 0, "default fee");
+        uint256 actualMinimumFee = constructedFactory.minimumFee();
+        assertEq(actualMinimumFee, 0, "minimum fee");
     }
 }

--- a/tests/integration/concrete/factory/create-merkle-instant/createMerkleInstant.t.sol
+++ b/tests/integration/concrete/factory/create-merkle-instant/createMerkleInstant.t.sol
@@ -52,7 +52,7 @@ contract CreateMerkleInstant_Integration_Test is Integration_Test {
         );
 
         // It should create the campaign with custom fee.
-        assertEq(actualInstant.FEE(), customFee, "fee");
+        assertEq(actualInstant.MINIMUM_FEE(), customFee, "fee");
 
         // It should set the current factory address.
         assertEq(actualInstant.FACTORY(), address(merkleFactory), "factory");
@@ -68,7 +68,7 @@ contract CreateMerkleInstant_Integration_Test is Integration_Test {
             params: merkleInstantConstructorParams(campaignOwner, expiration),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT(),
-            fee: defaults.FEE()
+            fee: defaults.MINIMUM_FEE()
         });
 
         ISablierMerkleInstant actualInstant = createMerkleInstant(campaignOwner, expiration);
@@ -78,7 +78,7 @@ contract CreateMerkleInstant_Integration_Test is Integration_Test {
         );
 
         // It should create the campaign with custom fee.
-        assertEq(actualInstant.FEE(), defaults.FEE(), "default fee");
+        assertEq(actualInstant.MINIMUM_FEE(), defaults.MINIMUM_FEE(), "minimum fee");
 
         // It should set the current factory address.
         assertEq(actualInstant.FACTORY(), address(merkleFactory), "factory");

--- a/tests/integration/concrete/factory/create-merkle-instant/createMerkleInstant.t.sol
+++ b/tests/integration/concrete/factory/create-merkle-instant/createMerkleInstant.t.sol
@@ -52,7 +52,7 @@ contract CreateMerkleInstant_Integration_Test is Integration_Test {
         );
 
         // It should create the campaign with custom fee.
-        assertEq(actualInstant.MINIMUM_FEE(), customFee, "fee");
+        assertEq(actualInstant.MINIMUM_FEE(), customFee, "custom fee");
 
         // It should set the current factory address.
         assertEq(actualInstant.FACTORY(), address(merkleFactory), "factory");

--- a/tests/integration/concrete/factory/create-merkle-instant/createMerkleInstant.tree
+++ b/tests/integration/concrete/factory/create-merkle-instant/createMerkleInstant.tree
@@ -7,6 +7,6 @@ CreateMerkleInstant_Integration_Test
    │  ├── it should set the current factory address
    │  └── it should emit a {CreateMerkleInstant} event
    └── given custom fee not set
-      ├── it should create the campaign with default fee
+      ├── it should create the campaign with minimum fee
       ├── it should set the current factory address
       └── it should emit a {CreateMerkleInstant} event

--- a/tests/integration/concrete/factory/create-merkle-ll/createMerkleLL.t.sol
+++ b/tests/integration/concrete/factory/create-merkle-ll/createMerkleLL.t.sol
@@ -50,7 +50,7 @@ contract CreateMerkleLL_Integration_Test is Integration_Test {
         assertEq(address(actualLL), expectedLL, "MerkleLL contract does not match computed address");
 
         // It should create the campaign with custom fee.
-        assertEq(actualLL.FEE(), customFee, "fee");
+        assertEq(actualLL.MINIMUM_FEE(), customFee, "fee");
 
         // It should set the current factory address.
         assertEq(actualLL.FACTORY(), address(merkleFactory), "factory");
@@ -66,7 +66,7 @@ contract CreateMerkleLL_Integration_Test is Integration_Test {
             params: merkleLLConstructorParams(campaignOwner, expiration),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT(),
-            fee: defaults.FEE()
+            fee: defaults.MINIMUM_FEE()
         });
 
         ISablierMerkleLL actualLL = createMerkleLL(campaignOwner, expiration);
@@ -77,7 +77,7 @@ contract CreateMerkleLL_Integration_Test is Integration_Test {
         assertEq(actualLL.shape(), defaults.SHAPE(), "shape");
 
         // It should create the campaign with custom fee.
-        assertEq(actualLL.FEE(), defaults.FEE(), "default fee");
+        assertEq(actualLL.MINIMUM_FEE(), defaults.MINIMUM_FEE(), "minimum fee");
 
         // It should set the current factory address.
         assertEq(actualLL.FACTORY(), address(merkleFactory), "factory");

--- a/tests/integration/concrete/factory/create-merkle-ll/createMerkleLL.t.sol
+++ b/tests/integration/concrete/factory/create-merkle-ll/createMerkleLL.t.sol
@@ -50,7 +50,7 @@ contract CreateMerkleLL_Integration_Test is Integration_Test {
         assertEq(address(actualLL), expectedLL, "MerkleLL contract does not match computed address");
 
         // It should create the campaign with custom fee.
-        assertEq(actualLL.MINIMUM_FEE(), customFee, "fee");
+        assertEq(actualLL.MINIMUM_FEE(), customFee, "custom fee");
 
         // It should set the current factory address.
         assertEq(actualLL.FACTORY(), address(merkleFactory), "factory");

--- a/tests/integration/concrete/factory/create-merkle-ll/createMerkleLL.tree
+++ b/tests/integration/concrete/factory/create-merkle-ll/createMerkleLL.tree
@@ -7,6 +7,6 @@ CreateMerkleLL_Integration_Test
    │  ├── it should set the current factory address
    │  └── it should emit a {CreateMerkleLL} event
    └── given custom fee not set
-      ├── it should create the campaign with default fee
+      ├── it should create the campaign with minimum fee
       ├── it should set the current factory address
       └── it should emit a {CreateMerkleLL} event

--- a/tests/integration/concrete/factory/create-merkle-lt/createMerkleLT.t.sol
+++ b/tests/integration/concrete/factory/create-merkle-lt/createMerkleLT.t.sol
@@ -50,7 +50,7 @@ contract CreateMerkleLT_Integration_Test is Integration_Test {
         assertEq(address(actualLT), expectedLT, "MerkleLT contract does not match computed address");
 
         // It should create the campaign with custom fee.
-        assertEq(actualLT.FEE(), customFee, "fee");
+        assertEq(actualLT.MINIMUM_FEE(), customFee, "fee");
         // It should set the current factory address.
         assertEq(actualLT.FACTORY(), address(merkleFactory), "factory");
     }
@@ -65,7 +65,7 @@ contract CreateMerkleLT_Integration_Test is Integration_Test {
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT(),
             totalDuration: defaults.TOTAL_DURATION(),
-            fee: defaults.FEE()
+            fee: defaults.MINIMUM_FEE()
         });
 
         ISablierMerkleLT actualLT = createMerkleLT(campaignOwner, expiration);
@@ -76,7 +76,7 @@ contract CreateMerkleLT_Integration_Test is Integration_Test {
         assertEq(actualLT.shape(), defaults.SHAPE(), "shape");
 
         // It should create the campaign with custom fee.
-        assertEq(actualLT.FEE(), defaults.FEE(), "default fee");
+        assertEq(actualLT.MINIMUM_FEE(), defaults.MINIMUM_FEE(), "minimum fee");
         // It should set the current factory address.
         assertEq(actualLT.FACTORY(), address(merkleFactory), "factory");
     }

--- a/tests/integration/concrete/factory/create-merkle-lt/createMerkleLT.t.sol
+++ b/tests/integration/concrete/factory/create-merkle-lt/createMerkleLT.t.sol
@@ -50,7 +50,7 @@ contract CreateMerkleLT_Integration_Test is Integration_Test {
         assertEq(address(actualLT), expectedLT, "MerkleLT contract does not match computed address");
 
         // It should create the campaign with custom fee.
-        assertEq(actualLT.MINIMUM_FEE(), customFee, "fee");
+        assertEq(actualLT.MINIMUM_FEE(), customFee, "custom fee");
         // It should set the current factory address.
         assertEq(actualLT.FACTORY(), address(merkleFactory), "factory");
     }

--- a/tests/integration/concrete/factory/create-merkle-lt/createMerkleLT.tree
+++ b/tests/integration/concrete/factory/create-merkle-lt/createMerkleLT.tree
@@ -7,6 +7,6 @@ CreateMerkleLT_Integration_Test
    │  ├── it should set the current factory address
    │  └── it should emit a {CreateMerkleLT} event
    └── given custom fee not set
-      ├── it should create the campaign with default fee
+      ├── it should create the campaign with minimum fee
       ├── it should set the current factory address
       └── it should emit a {CreateMerkleLT} event

--- a/tests/integration/concrete/factory/get-fee/getFee.t.sol
+++ b/tests/integration/concrete/factory/get-fee/getFee.t.sol
@@ -5,8 +5,8 @@ import { Integration_Test } from "../../../Integration.t.sol";
 
 contract GetFee_Integration_Test is Integration_Test {
     function test_GivenCustomFeeNotSet() external view {
-        // It should return default fee.
-        assertEq(merkleFactory.getFee(users.campaignOwner), defaults.FEE(), "default fee");
+        // It should return minimum fee.
+        assertEq(merkleFactory.getFee(users.campaignOwner), defaults.MINIMUM_FEE(), "minimum fee");
     }
 
     function test_GivenCustomFeeSet() external {

--- a/tests/integration/concrete/factory/get-fee/getFee.tree
+++ b/tests/integration/concrete/factory/get-fee/getFee.tree
@@ -1,5 +1,5 @@
 GetFee_Integration_Test
 ├── given custom fee not set
-│  └── it should return default fee
+│  └── it should return minimum fee
 └── given custom fee set
    └── it should return custom fee

--- a/tests/integration/concrete/factory/reset-custom-fee/resetCustomFee.t.sol
+++ b/tests/integration/concrete/factory/reset-custom-fee/resetCustomFee.t.sol
@@ -25,10 +25,10 @@ contract ResetCustomFee_Integration_Test is Integration_Test {
         MerkleFactory.CustomFee memory customFee = merkleFactory.getCustomFee(users.campaignOwner);
 
         // It should return false.
-        assertFalse(customFee.enabled, "enabled");
+        assertFalse(customFee.enabled, "custom fee enabled");
 
         // It should return 0 for the custom fee.
-        assertEq(customFee.fee, 0, "fee");
+        assertEq(customFee.fee, 0, "custom fee");
     }
 
     function test_WhenEnabled() external whenCallerAdmin {
@@ -38,8 +38,8 @@ contract ResetCustomFee_Integration_Test is Integration_Test {
         // Check that its enabled.
         MerkleFactory.CustomFee memory customFee = merkleFactory.getCustomFee(users.campaignOwner);
 
-        assertTrue(customFee.enabled, "enabled");
-        assertEq(customFee.fee, 1 ether, "fee");
+        assertTrue(customFee.enabled, "custom fee not enabled");
+        assertEq(customFee.fee, 1 ether, "custom fee");
 
         // It should emit a {ResetCustomFee} event.
         vm.expectEmit({ emitter: address(merkleFactory) });
@@ -51,9 +51,9 @@ contract ResetCustomFee_Integration_Test is Integration_Test {
         customFee = merkleFactory.getCustomFee(users.campaignOwner);
 
         // It should disable the custom fee
-        assertFalse(customFee.enabled, "enabled");
+        assertFalse(customFee.enabled, "custom fee enabled");
 
         // It should set the custom fee to 0
-        assertEq(customFee.fee, 0, "fee");
+        assertEq(customFee.fee, 0, "custom fee");
     }
 }

--- a/tests/integration/concrete/factory/set-custom-fee/setCustomFee.t.sol
+++ b/tests/integration/concrete/factory/set-custom-fee/setCustomFee.t.sol
@@ -29,10 +29,10 @@ contract SetCustomFee_Integration_Test is Integration_Test {
         MerkleFactory.CustomFee memory customFee = merkleFactory.getCustomFee(users.campaignOwner);
 
         // It should enable the custom fee.
-        assertTrue(customFee.enabled, "enabled");
+        assertTrue(customFee.enabled, "custom fee not enabled");
 
         // It should set the custom fee.
-        assertEq(customFee.fee, 0, "fee");
+        assertEq(customFee.fee, 0, "custom fee");
     }
 
     function test_WhenEnabled() external whenCallerAdmin {
@@ -40,8 +40,8 @@ contract SetCustomFee_Integration_Test is Integration_Test {
         merkleFactory.setCustomFee({ campaignCreator: users.campaignOwner, newFee: 0.001 ether });
         // Check that its enabled.
         MerkleFactory.CustomFee memory customFee = merkleFactory.getCustomFee(users.campaignOwner);
-        assertTrue(customFee.enabled, "enabled");
-        assertEq(customFee.fee, 0.001 ether, "fee");
+        assertTrue(customFee.enabled, "custom fee not enabled");
+        assertEq(customFee.fee, 0.001 ether, "custom fee");
 
         // It should emit a {SetCustomFee} event.
         vm.expectEmit({ emitter: address(merkleFactory) });
@@ -57,9 +57,9 @@ contract SetCustomFee_Integration_Test is Integration_Test {
         customFee = merkleFactory.getCustomFee(users.campaignOwner);
 
         // It should enable the custom fee.
-        assertTrue(customFee.enabled, "enabled");
+        assertTrue(customFee.enabled, "custom fee not enabled");
 
         // It should set the custom fee.
-        assertEq(customFee.fee, 1 ether, "fee");
+        assertEq(customFee.fee, 1 ether, "custom fee");
     }
 }

--- a/tests/integration/concrete/factory/set-default-fee/setDefaultFee.tree
+++ b/tests/integration/concrete/factory/set-default-fee/setDefaultFee.tree
@@ -1,6 +1,0 @@
-SetDefaultFee_Integration_Test
-├── when caller not admin
-│   └── it should revert
-└── when caller admin
-    ├── it should set the default fee
-    └── it should emit a {setDefaultFee} event

--- a/tests/integration/concrete/factory/set-minimum-fee/setMinimumFee.t.sol
+++ b/tests/integration/concrete/factory/set-minimum-fee/setMinimumFee.t.sol
@@ -5,24 +5,24 @@ import { ISablierMerkleFactory } from "src/interfaces/ISablierMerkleFactory.sol"
 import { Errors } from "src/libraries/Errors.sol";
 import { Integration_Test } from "./../../../Integration.t.sol";
 
-contract SetDefaultFee_Integration_Test is Integration_Test {
+contract SetMinimumFee_Integration_Test is Integration_Test {
     function test_RevertWhen_CallerNotAdmin() external {
-        uint256 fee = defaults.FEE();
+        uint256 minimumFee = defaults.MINIMUM_FEE();
         resetPrank({ msgSender: users.eve });
         vm.expectRevert(abi.encodeWithSelector(Errors.CallerNotAdmin.selector, users.admin, users.eve));
-        merkleFactory.setDefaultFee({ defaultFee: fee });
+        merkleFactory.setMinimumFee({ minimumFee: minimumFee });
     }
 
     function test_WhenCallerAdmin() external {
         resetPrank({ msgSender: users.admin });
 
-        // It should emit a {SetDefaultFee} event.
+        // It should emit a {SetMinimumFee} event.
         vm.expectEmit({ emitter: address(merkleFactory) });
-        emit ISablierMerkleFactory.SetDefaultFee({ admin: users.admin, defaultFee: defaults.FEE() });
+        emit ISablierMerkleFactory.SetMinimumFee({ admin: users.admin, minimumFee: defaults.MINIMUM_FEE() });
 
-        merkleFactory.setDefaultFee({ defaultFee: defaults.FEE() });
+        merkleFactory.setMinimumFee({ minimumFee: defaults.MINIMUM_FEE() });
 
-        // It should set the default fee.
-        assertEq(merkleFactory.defaultFee(), defaults.FEE(), "default fee");
+        // It should set the minimum fee.
+        assertEq(merkleFactory.minimumFee(), defaults.MINIMUM_FEE(), "minimum fee");
     }
 }

--- a/tests/integration/concrete/factory/set-minimum-fee/setMinimumFee.tree
+++ b/tests/integration/concrete/factory/set-minimum-fee/setMinimumFee.tree
@@ -1,0 +1,6 @@
+SetMinimumFee_Integration_Test
+├── when caller not admin
+│   └── it should revert
+└── when caller admin
+    ├── it should set the minimum fee
+    └── it should emit a {setMinimumFee} event

--- a/tests/integration/concrete/instant/claim/claim.t.sol
+++ b/tests/integration/concrete/instant/claim/claim.t.sol
@@ -27,11 +27,11 @@ contract Claim_MerkleInstant_Integration_Test is Claim_Integration_Test, MerkleI
         emit ISablierMerkleInstant.Claim(defaults.INDEX1(), users.recipient1, defaults.CLAIM_AMOUNT());
 
         expectCallToTransfer({ to: users.recipient1, value: defaults.CLAIM_AMOUNT() });
-        expectCallToClaimWithMsgValue(address(merkleInstant), defaults.FEE());
+        expectCallToClaimWithMsgValue(address(merkleInstant), defaults.MINIMUM_FEE());
         claim();
 
         assertTrue(merkleInstant.hasClaimed(defaults.INDEX1()), "not claimed");
 
-        assertEq(address(merkleInstant).balance, previousFeeAccrued + defaults.FEE(), "fee collected");
+        assertEq(address(merkleInstant).balance, previousFeeAccrued + defaults.MINIMUM_FEE(), "fee collected");
     }
 }

--- a/tests/integration/concrete/instant/constructor.t.sol
+++ b/tests/integration/concrete/instant/constructor.t.sol
@@ -51,8 +51,8 @@ contract Constructor_MerkleInstant_Integration_Test is Integration_Test {
         vars.expectedFactory = address(merkleFactory);
         assertEq(vars.actualFactory, vars.expectedFactory, "factory");
 
-        vars.actualFee = constructedInstant.FEE();
-        vars.expectedFee = defaults.FEE();
+        vars.actualFee = constructedInstant.MINIMUM_FEE();
+        vars.expectedFee = defaults.MINIMUM_FEE();
         assertEq(vars.actualFee, vars.expectedFee, "fee");
 
         vars.actualIpfsCID = constructedInstant.ipfsCID();

--- a/tests/integration/concrete/instant/constructor.t.sol
+++ b/tests/integration/concrete/instant/constructor.t.sol
@@ -53,7 +53,7 @@ contract Constructor_MerkleInstant_Integration_Test is Integration_Test {
 
         vars.actualFee = constructedInstant.MINIMUM_FEE();
         vars.expectedFee = defaults.MINIMUM_FEE();
-        assertEq(vars.actualFee, vars.expectedFee, "fee");
+        assertEq(vars.actualFee, vars.expectedFee, "minimum fee");
 
         vars.actualIpfsCID = constructedInstant.ipfsCID();
         vars.expectedIpfsCID = defaults.IPFS_CID();

--- a/tests/integration/concrete/ll/claim/claim.t.sol
+++ b/tests/integration/concrete/ll/claim/claim.t.sol
@@ -17,7 +17,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
     }
 
     function test_RevertWhen_TotalPercentageGreaterThan100() external whenMerkleProofValid {
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
 
         MerkleLL.ConstructorParams memory params = merkleLLConstructorParams();
 
@@ -93,7 +93,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
 
     /// @dev Helper function to test claim.
     function _test_Claim(uint40 startTime, uint40 cliffTime) private {
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
         deal({ token: address(dai), to: address(merkleLL), give: defaults.AGGREGATE_AMOUNT() });
 
         uint256 expectedStreamId = lockup.nextStreamId();
@@ -131,6 +131,6 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
 
         assertTrue(merkleLL.hasClaimed(defaults.INDEX1()), "not claimed");
 
-        assertEq(address(merkleLL).balance, previousFeeAccrued + defaults.FEE(), "fee collected");
+        assertEq(address(merkleLL).balance, previousFeeAccrued + defaults.MINIMUM_FEE(), "fee collected");
     }
 }

--- a/tests/integration/concrete/ll/constructor.t.sol
+++ b/tests/integration/concrete/ll/constructor.t.sol
@@ -66,7 +66,7 @@ contract Constructor_MerkleLL_Integration_Test is Integration_Test {
 
         vars.actualFee = constructedLL.MINIMUM_FEE();
         vars.expectedFee = defaults.MINIMUM_FEE();
-        assertEq(vars.actualFee, vars.expectedFee, "fee");
+        assertEq(vars.actualFee, vars.expectedFee, "minimum fee");
 
         vars.actualIpfsCID = constructedLL.ipfsCID();
         vars.expectedIpfsCID = defaults.IPFS_CID();

--- a/tests/integration/concrete/ll/constructor.t.sol
+++ b/tests/integration/concrete/ll/constructor.t.sol
@@ -64,8 +64,8 @@ contract Constructor_MerkleLL_Integration_Test is Integration_Test {
         vars.expectedFactory = address(merkleFactory);
         assertEq(vars.actualFactory, vars.expectedFactory, "factory");
 
-        vars.actualFee = constructedLL.FEE();
-        vars.expectedFee = defaults.FEE();
+        vars.actualFee = constructedLL.MINIMUM_FEE();
+        vars.expectedFee = defaults.MINIMUM_FEE();
         assertEq(vars.actualFee, vars.expectedFee, "fee");
 
         vars.actualIpfsCID = constructedLL.ipfsCID();

--- a/tests/integration/concrete/lt/claim/claim.t.sol
+++ b/tests/integration/concrete/lt/claim/claim.t.sol
@@ -16,7 +16,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
     }
 
     function test_RevertWhen_TotalPercentageLessThan100() external whenMerkleProofValid whenTotalPercentageNot100 {
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
 
         MerkleLT.ConstructorParams memory params = merkleLTConstructorParams();
 
@@ -40,7 +40,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
     }
 
     function test_RevertWhen_TotalPercentageGreaterThan100() external whenMerkleProofValid whenTotalPercentageNot100 {
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
 
         MerkleLT.ConstructorParams memory params = merkleLTConstructorParams();
 
@@ -83,7 +83,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
 
     /// @dev Helper function to test claim.
     function _test_Claim(uint40 streamStartTime, uint40 startTime) private {
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
 
         deal({ token: address(dai), to: address(merkleLT), give: defaults.AGGREGATE_AMOUNT() });
 
@@ -122,6 +122,6 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
 
         assertTrue(merkleLT.hasClaimed(defaults.INDEX1()), "not claimed");
 
-        assertEq(address(merkleLT).balance, previousFeeAccrued + defaults.FEE(), "fee collected");
+        assertEq(address(merkleLT).balance, previousFeeAccrued + defaults.MINIMUM_FEE(), "fee collected");
     }
 }

--- a/tests/integration/concrete/lt/constructor.t.sol
+++ b/tests/integration/concrete/lt/constructor.t.sol
@@ -71,8 +71,8 @@ contract Constructor_MerkleLT_Integration_Test is Integration_Test {
         vars.expectedFactory = address(merkleFactory);
         assertEq(vars.actualFactory, vars.expectedFactory, "factory");
 
-        vars.actualFee = constructedLT.FEE();
-        vars.expectedFee = defaults.FEE();
+        vars.actualFee = constructedLT.MINIMUM_FEE();
+        vars.expectedFee = defaults.MINIMUM_FEE();
         assertEq(vars.actualFee, vars.expectedFee, "fee");
 
         vars.actualIpfsCID = constructedLT.ipfsCID();

--- a/tests/integration/concrete/lt/constructor.t.sol
+++ b/tests/integration/concrete/lt/constructor.t.sol
@@ -73,7 +73,7 @@ contract Constructor_MerkleLT_Integration_Test is Integration_Test {
 
         vars.actualFee = constructedLT.MINIMUM_FEE();
         vars.expectedFee = defaults.MINIMUM_FEE();
-        assertEq(vars.actualFee, vars.expectedFee, "fee");
+        assertEq(vars.actualFee, vars.expectedFee, "minimum fee");
 
         vars.actualIpfsCID = constructedLT.ipfsCID();
         vars.expectedIpfsCID = defaults.IPFS_CID();

--- a/tests/integration/concrete/shared/claim/claim.t.sol
+++ b/tests/integration/concrete/shared/claim/claim.t.sol
@@ -8,7 +8,7 @@ import { Integration_Test } from "../../../Integration.t.sol";
 abstract contract Claim_Integration_Test is Integration_Test {
     function test_RevertGiven_CampaignExpired() external {
         uint40 expiration = defaults.EXPIRATION();
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
         uint256 warpTime = expiration + 1 seconds;
         bytes32[] memory merkleProof;
         vm.warp({ newTimestamp: warpTime });
@@ -20,7 +20,7 @@ abstract contract Claim_Integration_Test is Integration_Test {
         uint256 index1 = defaults.INDEX1();
         uint128 amount = defaults.CLAIM_AMOUNT();
         bytes32[] memory merkleProof = defaults.index1Proof();
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
 
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierMerkleBase_InsufficientFeePayment.selector, 0, fee));
         merkleBase.claim{ value: 0 }(index1, users.recipient1, amount, merkleProof);
@@ -30,7 +30,7 @@ abstract contract Claim_Integration_Test is Integration_Test {
         claim();
         uint256 index1 = defaults.INDEX1();
         uint128 amount = defaults.CLAIM_AMOUNT();
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
         bytes32[] memory merkleProof = defaults.index1Proof();
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierMerkleBase_StreamClaimed.selector, index1));
         merkleBase.claim{ value: fee }(index1, users.recipient1, amount, merkleProof);
@@ -44,7 +44,7 @@ abstract contract Claim_Integration_Test is Integration_Test {
     {
         uint256 invalidIndex = 1337;
         uint128 amount = defaults.CLAIM_AMOUNT();
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
         bytes32[] memory merkleProof = defaults.index1Proof();
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierMerkleBase_InvalidProof.selector));
         merkleBase.claim{ value: fee }(invalidIndex, users.recipient1, amount, merkleProof);
@@ -60,7 +60,7 @@ abstract contract Claim_Integration_Test is Integration_Test {
         uint256 index1 = defaults.INDEX1();
         address invalidRecipient = address(1337);
         uint128 amount = defaults.CLAIM_AMOUNT();
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
         bytes32[] memory merkleProof = defaults.index1Proof();
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierMerkleBase_InvalidProof.selector));
         merkleBase.claim{ value: fee }(index1, invalidRecipient, amount, merkleProof);
@@ -76,7 +76,7 @@ abstract contract Claim_Integration_Test is Integration_Test {
     {
         uint256 index1 = defaults.INDEX1();
         uint128 invalidAmount = 1337;
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
         bytes32[] memory merkleProof = defaults.index1Proof();
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierMerkleBase_InvalidProof.selector));
         merkleBase.claim{ value: fee }(index1, users.recipient1, invalidAmount, merkleProof);
@@ -93,7 +93,7 @@ abstract contract Claim_Integration_Test is Integration_Test {
     {
         uint256 index1 = defaults.INDEX1();
         uint128 amount = defaults.CLAIM_AMOUNT();
-        uint256 fee = defaults.FEE();
+        uint256 fee = defaults.MINIMUM_FEE();
         bytes32[] memory invalidMerkleProof = defaults.index2Proof();
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierMerkleBase_InvalidProof.selector));
         merkleBase.claim{ value: fee }(index1, users.recipient1, amount, invalidMerkleProof);

--- a/tests/integration/concrete/shared/collect-fees/collectFees.t.sol
+++ b/tests/integration/concrete/shared/collect-fees/collectFees.t.sol
@@ -69,6 +69,6 @@ abstract contract CollectFees_Integration_Test is Integration_Test {
         // It should set the ETH balance to 0.
         assertEq(address(merkleBase).balance, 0, "merkle lockup ETH balance");
         // It should transfer fee collected in ETH to the factory admin.
-        assertEq(admin.balance, initialAdminBalance + defaults.FEE(), "admin ETH balance");
+        assertEq(admin.balance, initialAdminBalance + defaults.MINIMUM_FEE(), "admin ETH balance");
     }
 }

--- a/tests/utils/Defaults.sol
+++ b/tests/utils/Defaults.sol
@@ -39,7 +39,6 @@ contract Defaults is Constants, Merkle {
     uint128 public constant CLAIM_AMOUNT = 10_000e18;
     UD2x18 public constant CLIFF_PERCENTAGE = UD2x18.wrap(0.25e18); // 25% of the claim amount
     uint40 public immutable EXPIRATION;
-    uint256 public constant FEE = 0.005e18;
     uint40 public constant FIRST_CLAIM_TIME = JULY_1_2024;
     uint256 public constant INDEX1 = 1;
     uint256 public constant INDEX2 = 2;
@@ -47,6 +46,7 @@ contract Defaults is Constants, Merkle {
     uint256 public constant INDEX4 = 4;
     string public constant IPFS_CID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
     uint256[] public LEAVES = new uint256[](RECIPIENT_COUNT);
+    uint256 public constant MINIMUM_FEE = 0.005e18;
     uint256 public constant RECIPIENT_COUNT = 4;
     bytes32 public MERKLE_ROOT;
     string public SHAPE = "A custom stream shape";


### PR DESCRIPTION
Closes https://github.com/sablier-labs/airdrops/issues/60

### Note

I didn't change the `getFee` function of Factory because it retrieves custom fee if set. So it makes sense to continue calling it `getFee`.

Also, from reference of Merkle contracts, its not relevant as a Merkle contract only depends on the local value of `MINIMUM_FEE`.