### PR TITLE
feat: get stream ids associated with airdrop claim

### DIFF
--- a/src/SablierMerkleLL.sol
+++ b/src/SablierMerkleLL.sol
@@ -123,6 +123,9 @@ contract SablierMerkleLL is
             cliffTime
         );
 
+        // Push the stream ID into the `_claimedStreams` array for the recipient.
+        _claimedStreams[recipient].push(streamId);
+
         // Log the claim.
         emit Claim(index, recipient, amount, streamId);
     }

--- a/src/SablierMerkleLL.sol
+++ b/src/SablierMerkleLL.sol
@@ -123,7 +123,7 @@ contract SablierMerkleLL is
             cliffTime
         );
 
-        // Push the stream ID into the `_claimedStreams` array for the recipient.
+        // Effect: push the stream ID into the `_claimedStreams` array for the recipient.
         _claimedStreams[recipient].push(streamId);
 
         // Log the claim.

--- a/src/SablierMerkleLT.sol
+++ b/src/SablierMerkleLT.sol
@@ -135,7 +135,7 @@ contract SablierMerkleLT is
             tranches
         );
 
-        // Push the stream ID into the `_claimedStreams` array for the recipient.
+        // Effect: push the stream ID into the `_claimedStreams` array for the recipient.
         _claimedStreams[recipient].push(streamId);
 
         // Log the claim.

--- a/src/SablierMerkleLT.sol
+++ b/src/SablierMerkleLT.sol
@@ -135,6 +135,9 @@ contract SablierMerkleLT is
             tranches
         );
 
+        // Push the stream ID into the `_claimedStreams` array for the recipient.
+        _claimedStreams[recipient].push(streamId);
+
         // Log the claim.
         emit Claim(index, recipient, amount, streamId);
     }

--- a/src/abstracts/SablierMerkleLockup.sol
+++ b/src/abstracts/SablierMerkleLockup.sol
@@ -32,6 +32,9 @@ abstract contract SablierMerkleLockup is
     /// @inheritdoc ISablierMerkleLockup
     string public override shape;
 
+    /// @dev A mapping of stream IDs associated with the airdrops claimed by the recipient.
+    mapping(address recipient => uint256[] streamIds) internal _claimedStreams;
+
     /*//////////////////////////////////////////////////////////////////////////
                                     CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
@@ -60,5 +63,14 @@ abstract contract SablierMerkleLockup is
 
         // Max approve the Lockup contract to spend funds from the Merkle Lockup campaigns.
         TOKEN.forceApprove(address(LOCKUP), type(uint256).max);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                           USER-FACING CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc ISablierMerkleLockup
+    function claimedStreams(address recipient) external view override returns (uint256[] memory) {
+        return _claimedStreams[recipient];
     }
 }

--- a/src/interfaces/ISablierMerkleLockup.sol
+++ b/src/interfaces/ISablierMerkleLockup.sol
@@ -29,6 +29,9 @@ interface ISablierMerkleLockup is ISablierMerkleBase {
     /// @dev This is an immutable state variable.
     function STREAM_TRANSFERABLE() external returns (bool);
 
+    /// @notice Retrieves the stream IDs associated with the airdrops claimed by the provided recipient.
+    function claimedStreams(address recipient) external view returns (uint256[] memory);
+
     /// @notice Retrieves the shape of the lockup stream that the campaign produces upon claiming.
     function shape() external view returns (string memory);
 }

--- a/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -234,6 +234,14 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
 
         assertTrue(vars.merkleLL.hasClaimed(vars.indexes[params.posBeforeSort]));
 
+        uint256[] memory expectedClaimedStreamIds = new uint256[](1);
+        expectedClaimedStreamIds[0] = vars.expectedStreamId;
+        assertEq(
+            vars.merkleLL.claimedStreams(vars.recipients[params.posBeforeSort]),
+            expectedClaimedStreamIds,
+            "claimed streams"
+        );
+
         /*//////////////////////////////////////////////////////////////////////////
                                         CLAWBACK
         //////////////////////////////////////////////////////////////////////////*/

--- a/tests/fork/merkle-campaign/MerkleLT.t.sol
+++ b/tests/fork/merkle-campaign/MerkleLT.t.sol
@@ -220,6 +220,14 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
 
         assertTrue(vars.merkleLT.hasClaimed(vars.indexes[params.posBeforeSort]));
 
+        uint256[] memory expectedClaimedStreamIds = new uint256[](1);
+        expectedClaimedStreamIds[0] = vars.expectedStreamId;
+        assertEq(
+            vars.merkleLT.claimedStreams(vars.recipients[params.posBeforeSort]),
+            expectedClaimedStreamIds,
+            "claimed streams"
+        );
+
         /*//////////////////////////////////////////////////////////////////////////
                                         CLAWBACK
         //////////////////////////////////////////////////////////////////////////*/

--- a/tests/integration/concrete/campaign/ll/claim/claim.t.sol
+++ b/tests/integration/concrete/campaign/ll/claim/claim.t.sol
@@ -120,6 +120,10 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
 
         assertTrue(merkleLL.hasClaimed(INDEX1), "not claimed");
 
+        uint256[] memory expectedClaimedStreamIds = new uint256[](1);
+        expectedClaimedStreamIds[0] = expectedStreamId;
+        assertEq(merkleLL.claimedStreams(users.recipient1), expectedClaimedStreamIds, "claimed streams");
+
         assertEq(address(merkleLL).balance, previousFeeAccrued + MINIMUM_FEE, "fee collected");
     }
 }

--- a/tests/integration/concrete/campaign/lt/claim/claim.t.sol
+++ b/tests/integration/concrete/campaign/lt/claim/claim.t.sol
@@ -105,6 +105,10 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
 
         assertTrue(merkleLT.hasClaimed(INDEX1), "not claimed");
 
+        uint256[] memory expectedClaimedStreamIds = new uint256[](1);
+        expectedClaimedStreamIds[0] = expectedStreamId;
+        assertEq(merkleLT.claimedStreams(users.recipient1), expectedClaimedStreamIds, "claimed streams");
+
         assertEq(address(merkleLT).balance, previousFeeAccrued + MINIMUM_FEE, "fee collected");
     }
 }


### PR DESCRIPTION
Closes https://github.com/sablier-labs/airdrops/issues/40

Depends on https://github.com/sablier-labs/airdrops/pull/71

~I went ahead with `claimedStreamIds` as the variable name because simply calling it `claimed` might confuse with the claimed amount. Feel free to suggest better names otherwise~

Based on https://github.com/sablier-labs/airdrops/issues/40#issuecomment-2668941441, I renamed it to `claimedStream`.