### PR TITLE
build: set high optimizer runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,7 @@
   ]
   gas_limit = 9223372036854775807
   optimizer = true
-  optimizer_runs = 1000
+  optimizer_runs = 1_000_000
   out = "out"
   script = "script"
   sender = "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38"


### PR DESCRIPTION
since we now have a minimal contract for each factory/campaign model, we can substantially increase the optimizer runs. 1M will produce these sizes:

| Contract                    | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| --------------------------- | ---------------- | ----------------- | ------------------ | ------------------- |
| SablierMerkleFactoryInstant | 8,536            | 8,716             | 16,040             | 40,436              |
| SablierMerkleFactoryLL      | 12,955           | 13,135            | 11,621             | 36,017              |
| SablierMerkleFactoryLT      | 14,540           | 14,720            | 10,036             | 34,432              |
| SablierMerkleFactoryVCA     | 9,666            | 9,846             | 14,910             | 39,306              |
| SablierMerkleInstant        | 4,191            | 5,640             | 20,385             | 43,512              |
| SablierMerkleLL             | 6,711            | 9,538             | 17,865             | 39,614              |
| SablierMerkleLT             | 7,658            | 10,705            | 16,918             | 38,447              |
| SablierMerkleVCA            | 4,822            | 6,634             | 19,754             | 42,518              |