### PR TITLE
feat: add fee recipient to `collectFees` function

### DIFF
--- a/src/abstracts/SablierFactoryMerkleBase.sol
+++ b/src/abstracts/SablierFactoryMerkleBase.sol
@@ -62,17 +62,17 @@ abstract contract SablierFactoryMerkleBase is
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ISablierFactoryMerkleBase
-    function collectFees(ISablierMerkleBase campaign, address to) external override {
-        // Check: if `msg.sender` is not the admin, `to` must be the admin address.
-        if (msg.sender != admin && to != admin) {
-            revert Errors.sablierMerkleFactoryBase_FeeRecipientNotAdmin({ feeRecipient: to, admin: admin });
+    function collectFees(ISablierMerkleBase campaign, address feeRecipient) external override {
+        // Check: if `msg.sender` is not the admin, `feeRecipient` must be the admin address.
+        if (msg.sender != admin && feeRecipient != admin) {
+            revert Errors.SablierMerkleFactoryBase_FeeRecipientNotAdmin({ feeRecipient: feeRecipient, admin: admin });
         }
 
         // Effect: collect the fees from the campaign contract.
-        uint256 feeAmount = campaign.collectFees(to);
+        uint256 feeAmount = campaign.collectFees(feeRecipient);
 
         // Log the fee withdrawal.
-        emit CollectFees({ feeRecipient: to, campaign: campaign, feeAmount: feeAmount });
+        emit CollectFees({ admin: admin, campaign: campaign, feeRecipient: feeRecipient, feeAmount: feeAmount });
     }
 
     /// @inheritdoc ISablierFactoryMerkleBase

--- a/src/abstracts/SablierFactoryMerkleBase.sol
+++ b/src/abstracts/SablierFactoryMerkleBase.sol
@@ -62,12 +62,17 @@ abstract contract SablierFactoryMerkleBase is
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ISablierFactoryMerkleBase
-    function collectFees(ISablierMerkleBase campaign) external override {
+    function collectFees(ISablierMerkleBase campaign, address to) external override {
+        // Check: if `msg.sender` is not the admin, `to` must be the admin address.
+        if (msg.sender != admin && to != admin) {
+            revert Errors.sablierMerkleFactoryBase_FeeRecipientNotAdmin({ feeRecipient: to, admin: admin });
+        }
+
         // Effect: collect the fees from the campaign contract.
-        uint256 feeAmount = campaign.collectFees(admin);
+        uint256 feeAmount = campaign.collectFees(to);
 
         // Log the fee withdrawal.
-        emit CollectFees({ admin: admin, campaign: campaign, feeAmount: feeAmount });
+        emit CollectFees({ feeRecipient: to, campaign: campaign, feeAmount: feeAmount });
     }
 
     /// @inheritdoc ISablierFactoryMerkleBase

--- a/src/abstracts/SablierMerkleBase.sol
+++ b/src/abstracts/SablierMerkleBase.sol
@@ -171,7 +171,7 @@ abstract contract SablierMerkleBase is
     }
 
     /// @inheritdoc ISablierMerkleBase
-    function collectFees(address to) external override returns (uint256 feeAmount) {
+    function collectFees(address feeRecipient) external override returns (uint256 feeAmount) {
         // Check: the caller is the FACTORY.
         if (msg.sender != address(FACTORY)) {
             revert Errors.SablierMerkleBase_CallerNotFactory({ factory: address(FACTORY), caller: msg.sender });
@@ -179,12 +179,12 @@ abstract contract SablierMerkleBase is
 
         feeAmount = address(this).balance;
 
-        // Effect: transfer the fees to the `to` address.
-        (bool success,) = to.call{ value: feeAmount }("");
+        // Effect: transfer the fees to the `feeRecipient` address.
+        (bool success,) = feeRecipient.call{ value: feeAmount }("");
 
         // Revert if the transfer failed.
         if (!success) {
-            revert Errors.SablierMerkleBase_FeeTransferFail(to, feeAmount);
+            revert Errors.SablierMerkleBase_FeeTransferFail(feeRecipient, feeAmount);
         }
     }
 

--- a/src/abstracts/SablierMerkleBase.sol
+++ b/src/abstracts/SablierMerkleBase.sol
@@ -28,7 +28,7 @@ abstract contract SablierMerkleBase is
     uint40 public immutable override EXPIRATION;
 
     /// @inheritdoc ISablierMerkleBase
-    address public immutable override FACTORY;
+    ISablierFactoryMerkleBase public immutable override FACTORY;
 
     /// @inheritdoc ISablierMerkleBase
     bytes32 public immutable override MERKLE_ROOT;
@@ -71,13 +71,13 @@ abstract contract SablierMerkleBase is
         Adminable(initialAdmin)
     {
         EXPIRATION = expiration;
-        FACTORY = msg.sender;
+        FACTORY = ISablierFactoryMerkleBase(msg.sender);
         MERKLE_ROOT = merkleRoot;
-        ORACLE = ISablierFactoryMerkleBase(FACTORY).oracle();
+        ORACLE = FACTORY.oracle();
         TOKEN = token;
         campaignName = campaignName_;
         ipfsCID = ipfsCID_;
-        minFeeUSD = ISablierFactoryMerkleBase(FACTORY).minFeeUSDFor(campaignCreator);
+        minFeeUSD = FACTORY.minFeeUSDFor(campaignCreator);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -171,20 +171,20 @@ abstract contract SablierMerkleBase is
     }
 
     /// @inheritdoc ISablierMerkleBase
-    function collectFees(address factoryAdmin) external override returns (uint256 feeAmount) {
+    function collectFees(address to) external override returns (uint256 feeAmount) {
         // Check: the caller is the FACTORY.
-        if (msg.sender != FACTORY) {
-            revert Errors.SablierMerkleBase_CallerNotFactory({ factory: FACTORY, caller: msg.sender });
+        if (msg.sender != address(FACTORY)) {
+            revert Errors.SablierMerkleBase_CallerNotFactory({ factory: address(FACTORY), caller: msg.sender });
         }
 
         feeAmount = address(this).balance;
 
-        // Effect: transfer the fees to the factory admin.
-        (bool success,) = factoryAdmin.call{ value: feeAmount }("");
+        // Effect: transfer the fees to the `to` address.
+        (bool success,) = to.call{ value: feeAmount }("");
 
         // Revert if the transfer failed.
         if (!success) {
-            revert Errors.SablierMerkleBase_FeeTransferFail(factoryAdmin, feeAmount);
+            revert Errors.SablierMerkleBase_FeeTransferFail(to, feeAmount);
         }
     }
 

--- a/src/interfaces/ISablierFactoryMerkleBase.sol
+++ b/src/interfaces/ISablierFactoryMerkleBase.sol
@@ -13,7 +13,9 @@ interface ISablierFactoryMerkleBase is IAdminable {
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Emitted when the accrued fees are collected.
-    event CollectFees(address indexed feeRecipient, ISablierMerkleBase indexed campaign, uint256 feeAmount);
+    event CollectFees(
+        address indexed admin, ISablierMerkleBase indexed campaign, address indexed feeRecipient, uint256 feeAmount
+    );
 
     /// @notice Emitted when the admin resets the custom USD fee for the provided campaign creator to the min fee.
     event DisableCustomFeeUSD(address indexed admin, address indexed campaignCreator);
@@ -68,15 +70,14 @@ interface ISablierFactoryMerkleBase is IAdminable {
     /// @dev Emits a {CollectFees} event.
     ///
     /// Notes:
-    /// - If the `to` address is a contract, it must be able to receive native token payments, e.g., ETH for Ethereum
-    /// Mainnet.
+    /// - If `feeRecipient` is a contract, it must be able to receive native tokens, e.g., ETH for Ethereum Mainnet.
     ///
     /// Requirements:
-    /// - If `msg.sender` is not the admin, `to` must be the admin address.
+    /// - If `msg.sender` is not the admin, `feeRecipient` must be the admin address.
     ///
     /// @param campaign The address of the Merkle contract to collect the fees from.
-    /// @param to The address where the fees will be transferred.
-    function collectFees(ISablierMerkleBase campaign, address to) external;
+    /// @param feeRecipient The address where the fees will be collected.
+    function collectFees(ISablierMerkleBase campaign, address feeRecipient) external;
 
     /// @notice Disables the custom USD fee for the provided campaign creator, who will now pay the min USD fee.
     /// @dev Emits a {DisableCustomFee} event.

--- a/src/interfaces/ISablierFactoryMerkleBase.sol
+++ b/src/interfaces/ISablierFactoryMerkleBase.sol
@@ -66,11 +66,9 @@ interface ISablierFactoryMerkleBase is IAdminable {
                                NON-CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Collects the fees accrued in the given campaign contract.
+    /// @notice Collects the fees accrued in the given campaign contract. If `feeRecipient` is a contract, it must be
+    /// able to receive native tokens, e.g., ETH for Ethereum Mainnet.
     /// @dev Emits a {CollectFees} event.
-    ///
-    /// Notes:
-    /// - If `feeRecipient` is a contract, it must be able to receive native tokens, e.g., ETH for Ethereum Mainnet.
     ///
     /// Requirements:
     /// - If `msg.sender` is not the admin, `feeRecipient` must be the admin address.

--- a/src/interfaces/ISablierFactoryMerkleBase.sol
+++ b/src/interfaces/ISablierFactoryMerkleBase.sol
@@ -13,7 +13,7 @@ interface ISablierFactoryMerkleBase is IAdminable {
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Emitted when the accrued fees are collected.
-    event CollectFees(address indexed admin, ISablierMerkleBase indexed campaign, uint256 feeAmount);
+    event CollectFees(address indexed feeRecipient, ISablierMerkleBase indexed campaign, uint256 feeAmount);
 
     /// @notice Emitted when the admin resets the custom USD fee for the provided campaign creator to the min fee.
     event DisableCustomFeeUSD(address indexed admin, address indexed campaignCreator);
@@ -64,14 +64,19 @@ interface ISablierFactoryMerkleBase is IAdminable {
                                NON-CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Collects the fees accrued in the given campaign contract, and transfers them to the factory admin.
+    /// @notice Collects the fees accrued in the given campaign contract.
     /// @dev Emits a {CollectFees} event.
     ///
     /// Notes:
-    /// - If the admin is a contract, it must be able to receive native token payments, e.g., ETH for Ethereum Mainnet.
+    /// - If the `to` address is a contract, it must be able to receive native token payments, e.g., ETH for Ethereum
+    /// Mainnet.
+    ///
+    /// Requirements:
+    /// - If `msg.sender` is not the admin, `to` must be the admin address.
     ///
     /// @param campaign The address of the Merkle contract to collect the fees from.
-    function collectFees(ISablierMerkleBase campaign) external;
+    /// @param to The address where the fees will be transferred.
+    function collectFees(ISablierMerkleBase campaign, address to) external;
 
     /// @notice Disables the custom USD fee for the provided campaign creator, who will now pay the min USD fee.
     /// @dev Emits a {DisableCustomFee} event.

--- a/src/interfaces/ISablierMerkleBase.sol
+++ b/src/interfaces/ISablierMerkleBase.sol
@@ -114,21 +114,21 @@ interface ISablierMerkleBase is IAdminable {
     /// @param amount The amount of tokens to claw back.
     function clawback(address to, uint128 amount) external;
 
-    /// @notice Collects the accrued fees by transferring them to the `to` address.
+    /// @notice Collects the accrued fees by transferring them to the `feeRecipient` address.
     ///
     /// Requirements:
     /// - `msg.sender` must be {FACTORY}.
     ///
-    /// @param to The address to receive the fees.
+    /// @param feeRecipient The address where the fees will be collected.
     /// @return feeAmount The amount of native tokens (e.g., ETH) collected as fees.
-    function collectFees(address to) external returns (uint256 feeAmount);
+    function collectFees(address feeRecipient) external returns (uint256 feeAmount);
 
     /// @notice Lowers the min USD fee.
     ///
     /// @dev Emits a {LowerMinFeeUSD} event.
     ///
     /// Requirements:
-    /// - `msg.sender` must have {FEE_MANAGEMENT_ROLE} role in {FACTORY}.
+    /// - `msg.sender` must be the admin of {FACTORY}.
     /// - The new fee must be less than the current {minFeeUSD}.
     /// @param newMinFeeUSD The new min USD fee to set, denominated in 8 decimals.
     function lowerMinFeeUSD(uint256 newMinFeeUSD) external;

--- a/src/interfaces/ISablierMerkleBase.sol
+++ b/src/interfaces/ISablierMerkleBase.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IAdminable } from "@sablier/evm-utils/src/interfaces/IAdminable.sol";
+import { ISablierFactoryMerkleBase } from "./ISablierFactoryMerkleBase.sol";
 
 /// @title ISablierMerkleBase
 /// @dev Common interface between campaign contracts.
@@ -26,7 +27,7 @@ interface ISablierMerkleBase is IAdminable {
     function EXPIRATION() external returns (uint40);
 
     /// @notice Retrieves the address of the factory contract.
-    function FACTORY() external view returns (address);
+    function FACTORY() external view returns (ISablierFactoryMerkleBase);
 
     /// @notice The root of the Merkle tree used to validate the proofs of inclusion.
     /// @dev This is an immutable state variable.
@@ -113,21 +114,21 @@ interface ISablierMerkleBase is IAdminable {
     /// @param amount The amount of tokens to claw back.
     function clawback(address to, uint128 amount) external;
 
-    /// @notice Collects the accrued fees by transferring them to {FACTORY}.
+    /// @notice Collects the accrued fees by transferring them to the `to` address.
     ///
     /// Requirements:
     /// - `msg.sender` must be {FACTORY}.
     ///
-    /// @param factoryAdmin The address of the admin of {FACTORY}.
+    /// @param to The address to receive the fees.
     /// @return feeAmount The amount of native tokens (e.g., ETH) collected as fees.
-    function collectFees(address factoryAdmin) external returns (uint256 feeAmount);
+    function collectFees(address to) external returns (uint256 feeAmount);
 
     /// @notice Lowers the min USD fee.
     ///
     /// @dev Emits a {LowerMinFeeUSD} event.
     ///
     /// Requirements:
-    /// - `msg.sender` must be the admin of {FACTORY}.
+    /// - `msg.sender` must have {FEE_MANAGEMENT_ROLE} role in {FACTORY}.
     /// - The new fee must be less than the current {minFeeUSD}.
     /// @param newMinFeeUSD The new min USD fee to set, denominated in 8 decimals.
     function lowerMinFeeUSD(uint256 newMinFeeUSD) external;

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -42,9 +42,8 @@ library Errors {
                             SABLIER-MERKLE-FACTORY-BASE
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Thrown when non-admin address calls {collectFees} without setting the fee recipient to the admin
-    /// address.
-    error sablierMerkleFactoryBase_FeeRecipientNotAdmin(address feeRecipient, address admin);
+    /// @notice Thrown when a non-admin address calls {collectFees} without setting the fee recipient to admin address.
+    error SablierMerkleFactoryBase_FeeRecipientNotAdmin(address feeRecipient, address admin);
 
     /// @notice Thrown when trying to create a campaign with native token.
     error SablierFactoryMerkleBase_ForbidNativeToken(address nativeToken);

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -42,6 +42,10 @@ library Errors {
                             SABLIER-MERKLE-FACTORY-BASE
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @notice Thrown when non-admin address calls {collectFees} without setting the fee recipient to the admin
+    /// address.
+    error sablierMerkleFactoryBase_FeeRecipientNotAdmin(address feeRecipient, address admin);
+
     /// @notice Thrown when trying to create a campaign with native token.
     error SablierFactoryMerkleBase_ForbidNativeToken(address nativeToken);
 

--- a/tests/fork/merkle-campaign/MerkleBase.t.sol
+++ b/tests/fork/merkle-campaign/MerkleBase.t.sol
@@ -139,11 +139,11 @@ abstract contract MerkleBase_Fork_Test is Fork_Test {
 
         vm.expectEmit({ emitter: address(factoryMerkleBase) });
         emit ISablierFactoryMerkleBase.CollectFees({
-            admin: factoryAdmin,
+            feeRecipient: factoryAdmin,
             campaign: merkleBase,
             feeAmount: vars.minFeeWei
         });
-        factoryMerkleBase.collectFees({ campaign: merkleBase });
+        factoryMerkleBase.collectFees({ campaign: merkleBase, to: factoryAdmin });
 
         assertEq(address(merkleBase).balance, 0, "merkle ETH balance");
         assertEq(factoryAdmin.balance, vars.initialAdminBalance + vars.minFeeWei, "admin ETH balance");

--- a/tests/fork/merkle-campaign/MerkleBase.t.sol
+++ b/tests/fork/merkle-campaign/MerkleBase.t.sol
@@ -139,11 +139,12 @@ abstract contract MerkleBase_Fork_Test is Fork_Test {
 
         vm.expectEmit({ emitter: address(factoryMerkleBase) });
         emit ISablierFactoryMerkleBase.CollectFees({
-            feeRecipient: factoryAdmin,
+            admin: factoryAdmin,
             campaign: merkleBase,
+            feeRecipient: factoryAdmin,
             feeAmount: vars.minFeeWei
         });
-        factoryMerkleBase.collectFees({ campaign: merkleBase, to: factoryAdmin });
+        factoryMerkleBase.collectFees({ campaign: merkleBase, feeRecipient: factoryAdmin });
 
         assertEq(address(merkleBase).balance, 0, "merkle ETH balance");
         assertEq(factoryAdmin.balance, vars.initialAdminBalance + vars.minFeeWei, "admin ETH balance");

--- a/tests/integration/concrete/campaign/instant/constructor.t.sol
+++ b/tests/integration/concrete/campaign/instant/constructor.t.sol
@@ -18,7 +18,7 @@ contract Constructor_MerkleInstant_Integration_Test is MerkleInstant_Integration
         assertEq(constructedInstant.admin(), users.campaignCreator, "admin");
         assertEq(constructedInstant.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedInstant.EXPIRATION(), EXPIRATION, "expiration");
-        assertEq(constructedInstant.FACTORY(), address(factoryMerkleInstant), "factory");
+        assertEq(address(constructedInstant.FACTORY()), address(factoryMerkleInstant), "factory");
         assertEq(constructedInstant.ipfsCID(), IPFS_CID, "IPFS CID");
         assertEq(constructedInstant.MERKLE_ROOT(), MERKLE_ROOT, "merkleRoot");
         assertEq(constructedInstant.minFeeUSD(), MIN_FEE_USD, "min fee USD");

--- a/tests/integration/concrete/campaign/ll/constructor.t.sol
+++ b/tests/integration/concrete/campaign/ll/constructor.t.sol
@@ -21,7 +21,7 @@ contract Constructor_MerkleLL_Integration_Test is Integration_Test {
         assertEq(constructedLL.admin(), users.campaignCreator, "admin");
         assertEq(constructedLL.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedLL.EXPIRATION(), EXPIRATION, "expiration");
-        assertEq(constructedLL.FACTORY(), address(factoryMerkleLL), "factory");
+        assertEq(address(constructedLL.FACTORY()), address(factoryMerkleLL), "factory");
         assertEq(constructedLL.ipfsCID(), IPFS_CID, "IPFS CID");
         assertEq(constructedLL.MERKLE_ROOT(), MERKLE_ROOT, "merkleRoot");
         assertEq(constructedLL.minFeeUSD(), MIN_FEE_USD, "min fee USD");

--- a/tests/integration/concrete/campaign/shared/collect-fees/collectFees.tree
+++ b/tests/integration/concrete/campaign/shared/collect-fees/collectFees.tree
@@ -2,12 +2,12 @@ CollectFees_Integration_Test
 ├── when caller not factory
 │  └── it should revert
 └── when caller factory
-   ├── when factory admin is not contract
-   │  ├── it should transfer fee collected in ETH to the factory admin
+   ├── when fee recipient not contract
+   │  ├── it should transfer fee collected in ETH to the fee recipient
    │  └── it should set the ETH balance to 0
-   └── when factory admin is contract
-      ├── when factory admin does not implement receive function
+   └── when fee recipient contract
+      ├── when fee recipient does not implement receive function
       │  └── it should revert
-      └── when factory admin implements receive function
-         ├── it should transfer fee collected in ETH to the factory admin
+      └── when fee recipient implements receive function
+         ├── it should transfer fee collected in ETH to the fee recipient
          └── it should set the ETH balance to 0

--- a/tests/integration/concrete/campaign/vca/constructor.t.sol
+++ b/tests/integration/concrete/campaign/vca/constructor.t.sol
@@ -17,7 +17,7 @@ contract Constructor_MerkleVCA_Integration_Test is MerkleVCA_Integration_Shared_
         assertEq(constructedVCA.admin(), users.campaignCreator, "admin");
         assertEq(constructedVCA.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedVCA.EXPIRATION(), EXPIRATION, "expiration");
-        assertEq(constructedVCA.FACTORY(), address(factoryMerkleVCA), "factory");
+        assertEq(address(constructedVCA.FACTORY()), address(factoryMerkleVCA), "factory");
         assertEq(constructedVCA.ipfsCID(), IPFS_CID, "IPFS CID");
         assertEq(constructedVCA.MERKLE_ROOT(), MERKLE_ROOT, "Merkle root");
         assertEq(constructedVCA.minFeeUSD(), MIN_FEE_USD, "min fee USD");

--- a/tests/integration/concrete/factory/instant/create-merkle-instant/createMerkleInstant.t.sol
+++ b/tests/integration/concrete/factory/instant/create-merkle-instant/createMerkleInstant.t.sol
@@ -63,7 +63,7 @@ contract CreateMerkleInstant_Integration_Test is Integration_Test {
         );
 
         // It should set the current factory address.
-        assertEq(actualInstant.FACTORY(), address(factoryMerkleInstant));
+        assertEq(address(actualInstant.FACTORY()), address(factoryMerkleInstant));
         assertEq(actualInstant.minFeeUSD(), customFeeUSD, "min fee USD");
     }
 
@@ -91,7 +91,7 @@ contract CreateMerkleInstant_Integration_Test is Integration_Test {
         );
 
         // It should set the current factory address.
-        assertEq(actualInstant.FACTORY(), address(factoryMerkleInstant));
+        assertEq(address(actualInstant.FACTORY()), address(factoryMerkleInstant));
         assertEq(actualInstant.minFeeUSD(), MIN_FEE_USD, "min fee USD");
     }
 }

--- a/tests/integration/concrete/factory/ll/create-merkle-ll/createMerkleLL.t.sol
+++ b/tests/integration/concrete/factory/ll/create-merkle-ll/createMerkleLL.t.sol
@@ -60,7 +60,7 @@ contract CreateMerkleLL_Integration_Test is Integration_Test {
         assertEq(address(actualLL), expectedLL, "MerkleLL contract does not match computed address");
 
         // It should set the current factory address.
-        assertEq(actualLL.FACTORY(), address(factoryMerkleLL), "factory");
+        assertEq(address(actualLL.FACTORY()), address(factoryMerkleLL), "factory");
         assertEq(actualLL.minFeeUSD(), customFeeUSD, "min fee USD");
     }
 
@@ -89,7 +89,7 @@ contract CreateMerkleLL_Integration_Test is Integration_Test {
         assertEq(actualLL.streamShape(), STREAM_SHAPE, "stream shape");
 
         // It should set the current factory address.
-        assertEq(actualLL.FACTORY(), address(factoryMerkleLL), "factory");
+        assertEq(address(actualLL.FACTORY()), address(factoryMerkleLL), "factory");
         assertEq(actualLL.minFeeUSD(), MIN_FEE_USD, "min fee USD");
     }
 }

--- a/tests/integration/concrete/factory/lt/create-merkle-lt/createMerkleLT.t.sol
+++ b/tests/integration/concrete/factory/lt/create-merkle-lt/createMerkleLT.t.sol
@@ -60,7 +60,7 @@ contract CreateMerkleLT_Integration_Test is Integration_Test {
         assertEq(address(actualLT), expectedLT, "MerkleLT contract does not match computed address");
 
         // It should set the current factory address.
-        assertEq(actualLT.FACTORY(), address(factoryMerkleLT), "factory");
+        assertEq(address(actualLT.FACTORY()), address(factoryMerkleLT), "factory");
         assertEq(actualLT.minFeeUSD(), customFeeUSD, "min fee USD");
     }
 
@@ -89,7 +89,7 @@ contract CreateMerkleLT_Integration_Test is Integration_Test {
         assertEq(actualLT.streamShape(), STREAM_SHAPE, "stream shape");
 
         // It should set the current factory address.
-        assertEq(actualLT.FACTORY(), address(factoryMerkleLT), "factory");
+        assertEq(address(actualLT.FACTORY()), address(factoryMerkleLT), "factory");
         assertEq(actualLT.minFeeUSD(), MIN_FEE_USD, "min fee USD");
     }
 }

--- a/tests/integration/concrete/factory/shared/collect-fees/collectFees.t.sol
+++ b/tests/integration/concrete/factory/shared/collect-fees/collectFees.t.sol
@@ -9,16 +9,16 @@ import { Integration_Test } from "./../../../../Integration.t.sol";
 abstract contract CollectFees_Integration_Test is Integration_Test {
     function test_RevertWhen_ProvidedMerkleLockupNotValid() external {
         vm.expectRevert();
-        factoryMerkleBase.collectFees({ campaign: ISablierMerkleBase(users.eve), to: users.admin });
+        factoryMerkleBase.collectFees({ campaign: ISablierMerkleBase(users.eve), feeRecipient: users.admin });
     }
 
     function test_RevertWhen_FeeRecipientNotAdmin() external whenProvidedMerkleLockupValid whenCallerNotAdmin {
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.sablierMerkleFactoryBase_FeeRecipientNotAdmin.selector, users.eve, users.admin
+                Errors.SablierMerkleFactoryBase_FeeRecipientNotAdmin.selector, users.eve, users.admin
             )
         );
-        factoryMerkleBase.collectFees({ campaign: merkleBase, to: users.eve });
+        factoryMerkleBase.collectFees({ campaign: merkleBase, feeRecipient: users.eve });
     }
 
     function test_WhenFeeRecipientAdmin() external whenProvidedMerkleLockupValid whenCallerNotAdmin {
@@ -44,7 +44,7 @@ abstract contract CollectFees_Integration_Test is Integration_Test {
                 address(merkleBase).balance
             )
         );
-        factoryMerkleBase.collectFees({ campaign: merkleBase, to: address(contractWithoutReceive) });
+        factoryMerkleBase.collectFees({ campaign: merkleBase, feeRecipient: address(contractWithoutReceive) });
     }
 
     function test_WhenFeeRecipientImplementsReceiveFunction()
@@ -63,12 +63,13 @@ abstract contract CollectFees_Integration_Test is Integration_Test {
         // It should emit a {CollectFees} event.
         vm.expectEmit({ emitter: address(factoryMerkleBase) });
         emit ISablierFactoryMerkleBase.CollectFees({
-            feeRecipient: feeRecipient,
+            admin: users.admin,
             campaign: merkleBase,
+            feeRecipient: feeRecipient,
             feeAmount: MIN_FEE_WEI
         });
 
-        factoryMerkleBase.collectFees({ campaign: merkleBase, to: feeRecipient });
+        factoryMerkleBase.collectFees({ campaign: merkleBase, feeRecipient: feeRecipient });
 
         // It should decrease merkle contract balance to zero.
         assertEq(address(merkleBase).balance, 0, "merkle lockup ETH balance");

--- a/tests/integration/concrete/factory/shared/collect-fees/collectFees.t.sol
+++ b/tests/integration/concrete/factory/shared/collect-fees/collectFees.t.sol
@@ -9,25 +9,34 @@ import { Integration_Test } from "./../../../../Integration.t.sol";
 abstract contract CollectFees_Integration_Test is Integration_Test {
     function test_RevertWhen_ProvidedMerkleLockupNotValid() external {
         vm.expectRevert();
-        factoryMerkleBase.collectFees(ISablierMerkleBase(users.eve));
+        factoryMerkleBase.collectFees({ campaign: ISablierMerkleBase(users.eve), to: users.admin });
     }
 
-    function test_WhenFactoryAdminIsNotContract() external whenProvidedMerkleLockupValid {
-        _test_CollectFees(users.admin);
+    function test_RevertWhen_FeeRecipientNotAdmin() external whenProvidedMerkleLockupValid whenCallerNotAdmin {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.sablierMerkleFactoryBase_FeeRecipientNotAdmin.selector, users.eve, users.admin
+            )
+        );
+        factoryMerkleBase.collectFees({ campaign: merkleBase, to: users.eve });
     }
 
-    function test_RevertWhen_FactoryAdminDoesNotImplementReceiveFunction()
+    function test_WhenFeeRecipientAdmin() external whenProvidedMerkleLockupValid whenCallerNotAdmin {
+        // It should transfer fee to the admin.
+        _test_CollectFees({ feeRecipient: users.admin });
+    }
+
+    function test_WhenFeeRecipientNotContract() external whenProvidedMerkleLockupValid whenCallerAdmin {
+        // It should transfer fee to the fee recipient.
+        _test_CollectFees({ feeRecipient: users.recipient });
+    }
+
+    function test_RevertWhen_FeeRecipientDoesNotImplementReceiveFunction()
         external
         whenProvidedMerkleLockupValid
-        whenFactoryAdminIsContract
+        whenCallerAdmin
+        whenFeeRecipientContract
     {
-        // Transfer the admin to a contract that does not implement the receive function.
-        setMsgSender(users.admin);
-        factoryMerkleBase.transferAdmin(address(contractWithoutReceive));
-
-        // Make the contract the caller.
-        setMsgSender(address(contractWithoutReceive));
-
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierMerkleBase_FeeTransferFail.selector,
@@ -35,38 +44,36 @@ abstract contract CollectFees_Integration_Test is Integration_Test {
                 address(merkleBase).balance
             )
         );
-        factoryMerkleBase.collectFees(merkleBase);
+        factoryMerkleBase.collectFees({ campaign: merkleBase, to: address(contractWithoutReceive) });
     }
 
-    function test_WhenFactoryAdminImplementsReceiveFunction()
+    function test_WhenFeeRecipientImplementsReceiveFunction()
         external
         whenProvidedMerkleLockupValid
-        whenFactoryAdminIsContract
+        whenCallerAdmin
+        whenFeeRecipientContract
     {
-        // Transfer the admin to a contract that implements the receive function.
-        setMsgSender(users.admin);
-        factoryMerkleBase.transferAdmin(address(contractWithReceive));
-
         _test_CollectFees(address(contractWithReceive));
     }
 
-    function _test_CollectFees(address admin) private {
-        // Load the initial ETH balance of the admin.
-        uint256 initialAdminBalance = admin.balance;
+    function _test_CollectFees(address feeRecipient) private {
+        // Load the initial ETH balance of the fee recipient.
+        uint256 initialFeeRecipientBalance = feeRecipient.balance;
 
         // It should emit a {CollectFees} event.
         vm.expectEmit({ emitter: address(factoryMerkleBase) });
-        emit ISablierFactoryMerkleBase.CollectFees({ admin: admin, campaign: merkleBase, feeAmount: MIN_FEE_WEI });
+        emit ISablierFactoryMerkleBase.CollectFees({
+            feeRecipient: feeRecipient,
+            campaign: merkleBase,
+            feeAmount: MIN_FEE_WEI
+        });
 
-        // Make Alice the caller.
-        setMsgSender(users.eve);
-
-        factoryMerkleBase.collectFees(merkleBase);
+        factoryMerkleBase.collectFees({ campaign: merkleBase, to: feeRecipient });
 
         // It should decrease merkle contract balance to zero.
         assertEq(address(merkleBase).balance, 0, "merkle lockup ETH balance");
 
-        // It should transfer fee to the factory admin.
-        assertEq(admin.balance, initialAdminBalance + MIN_FEE_WEI, "admin ETH balance");
+        // It should transfer fee to the fee recipient.
+        assertEq(feeRecipient.balance, initialFeeRecipientBalance + MIN_FEE_WEI, "fee recipient ETH balance");
     }
 }

--- a/tests/integration/concrete/factory/shared/collect-fees/collectFees.tree
+++ b/tests/integration/concrete/factory/shared/collect-fees/collectFees.tree
@@ -2,14 +2,22 @@ CollectFees_Integration_Test
 ├── when provided merkle lockup not valid
 │  └── it should revert
 └── when provided merkle lockup valid
-   ├── when factory admin is not contract
-   │  ├── it should transfer fee to the factory admin
-   │  ├── it should decrease merkle contract balance to zero
-   │  └── it should emit a {CollectFees} event
-   └── when factory admin is contract
-      ├── when factory admin does not implement receive function
-      │  └── it should revert
-      └── when factory admin implements receive function
-         ├── it should transfer fee to the factory admin
-         ├── it should decrease merkle contract balance to zero
-         └── it should emit a {CollectFees} event
+   ├── when caller not admin
+   │  ├── when fee recipient not admin
+   │  │  └── it should revert
+   │  └── when fee recipient admin
+   │     ├── it should transfer fee to the admin
+   │     ├── it should decrease merkle contract balance to zero
+   │     └── it should emit a {CollectFees} event
+   └── when caller admin
+      ├── when fee recipient not contract
+      │  ├── it should transfer fee to the fee recipient
+      │  ├── it should decrease merkle contract balance to zero
+      │  └── it should emit a {CollectFees} event
+      └── when fee recipient contract
+         ├── when fee recipient does not implement receive function
+         │  └── it should revert
+         └── when fee recipient implements receive function
+            ├── it should transfer fee to the fee recipient
+            ├── it should decrease merkle contract balance to zero
+            └── it should emit a {CollectFees} event

--- a/tests/integration/concrete/factory/vca/create-merkle-vca/createMerkleVCA.t.sol
+++ b/tests/integration/concrete/factory/vca/create-merkle-vca/createMerkleVCA.t.sol
@@ -178,7 +178,7 @@ contract CreateMerkleVCA_Integration_Test is Integration_Test {
         assertEq(actualVCA.minFeeUSD(), customFeeUSD, "custom fee USD");
 
         // It should set the current factory address.
-        assertEq(actualVCA.FACTORY(), address(factoryMerkleVCA), "factory");
+        assertEq(address(actualVCA.FACTORY()), address(factoryMerkleVCA), "factory");
 
         // It should set the correct vesting end time.
         assertEq(actualVCA.VESTING_END_TIME(), VESTING_END_TIME, "vesting end time");
@@ -220,7 +220,7 @@ contract CreateMerkleVCA_Integration_Test is Integration_Test {
         // It should create the campaign.
         assertEq(actualVCA.minFeeUSD(), MIN_FEE_USD, "min fee USD");
         // It should set the current factory address.
-        assertEq(actualVCA.FACTORY(), address(factoryMerkleVCA), "factory");
+        assertEq(address(actualVCA.FACTORY()), address(factoryMerkleVCA), "factory");
 
         // It should set the correct vesting end time.
         assertEq(actualVCA.VESTING_END_TIME(), VESTING_END_TIME, "vesting end time");

--- a/tests/integration/fuzz/Fuzz.t.sol
+++ b/tests/integration/fuzz/Fuzz.t.sol
@@ -147,7 +147,7 @@ contract Shared_Fuzz_Test is Integration_Test {
         uint256 initialAdminBalance = users.admin.balance;
 
         // Collect the fees earned.
-        factoryMerkleBase.collectFees({ campaign: merkleBase, to: users.admin });
+        factoryMerkleBase.collectFees({ campaign: merkleBase, feeRecipient: users.admin });
 
         // It should decrease merkle contract balance to zero.
         assertEq(address(merkleBase).balance, 0, "merkle base ETH balance");

--- a/tests/integration/fuzz/Fuzz.t.sol
+++ b/tests/integration/fuzz/Fuzz.t.sol
@@ -146,8 +146,8 @@ contract Shared_Fuzz_Test is Integration_Test {
         // Load the initial ETH balance of the admin.
         uint256 initialAdminBalance = users.admin.balance;
 
-        // collect the fees earned.
-        factoryMerkleBase.collectFees(merkleBase);
+        // Collect the fees earned.
+        factoryMerkleBase.collectFees({ campaign: merkleBase, to: users.admin });
 
         // It should decrease merkle contract balance to zero.
         assertEq(address(merkleBase).balance, 0, "merkle base ETH balance");

--- a/tests/utils/Modifiers.sol
+++ b/tests/utils/Modifiers.sol
@@ -71,6 +71,10 @@ abstract contract Modifiers is EvmUtilsBase {
         _;
     }
 
+    modifier whenCallerNotAdmin() {
+        _;
+    }
+
     modifier whenClaimTimeGreaterThanStartTime() {
         _;
     }
@@ -96,6 +100,10 @@ abstract contract Modifiers is EvmUtilsBase {
     }
 
     modifier whenFactoryAdminIsContract() {
+        _;
+    }
+
+    modifier whenFeeRecipientContract() {
         _;
     }
 


### PR DESCRIPTION
### Changelog

- Closes https://github.com/sablier-labs/airdrops/issues/139
- Changes the type of `FACTORY` constant to `ISablierFactoryMerkleBase`. The number of times its casted from `address` to `ISablierFactoryMerkleBase` would be higher after RBAC PR. So it would be useful.

### Notes

I have used `to` as the input parameter of `collectFees` functions. However, I have referred to it as fee recipient or `feeRecipient` in tests, events and errors. I would prefer renaming `to` to `feeRecipient` in function parameter as well. Let me know if you agree.