### PR TITLE
chore: fix taplo TOML formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,12 @@
     "editor.defaultFormatter": "tamasfe.even-better-toml"
   },
   "editor.formatOnSave": true,
+  "evenBetterToml.formatter.alignComments": true,
+  "evenBetterToml.formatter.arrayAutoCollapse": false,
+  "evenBetterToml.formatter.columnWidth": 120,
+  "evenBetterToml.formatter.reorderArrays": true,
+  "evenBetterToml.formatter.reorderKeys": true,
+  "evenBetterToml.formatter.reorderInlineTables": true,
   "search.exclude": {
     "**/node_modules": true
   },

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
   evm_version = "shanghai" # needed for greater coverage of EVM chains
   fs_permissions = [
     { access = "read", path = "./out-optimized" },
-    { access = "read", path = "package.json" }
+    { access = "read", path = "package.json" },
   ]
   gas_limit = 9223372036854775807
   optimizer = true
@@ -52,7 +52,6 @@
   show_proved_safe = true
   show_unproved = true
   show_unsupported = true
-  timeout = 100_000 # in milliseconds, per solving query
   targets = [
     "assert",
     "constantCondition",
@@ -61,6 +60,7 @@
     "overflow",
     "underflow",
   ]
+  timeout = 100_000 # in milliseconds, per solving query
 
 # Test the optimized contracts without re-compiling them
 [profile.test-optimized]
@@ -85,7 +85,7 @@
   wrap_comments = true
 
 [rpc_endpoints]
-  # mainnets
+  # Mainnets
   arbitrum = "https://arbitrum-mainnet.infura.io/v3/${API_KEY_INFURA}"
   avalanche = "https://avalanche-mainnet.infura.io/v3/${API_KEY_INFURA}"
   base = "https://mainnet.base.org"
@@ -109,7 +109,7 @@
   superseed = "https://mainnet.superseed.xyz"
   taiko_mainnet = "https://rpc.mainnet.taiko.xyz"
   xdc = "https://rpc.xdc.org"
-  # testnets
+  # Testnets
   arbitrum_sepolia = "https://arbitrum-sepolia-rpc.publicnode.com"
   base_sepolia = "https://sepolia.base.org"
   berachain_artio = "https://bartio.rpc.berachain.com/"


### PR DESCRIPTION
I noticed that the Taplo formatter didn't work because of this bug:

https://github.com/tamasfe/taplo/issues/741

The fix is to set the `columnWidth` to 120 and disable `arrayAutoCollapse`.