### PR TITLE
feat: add validity start time for claim signature

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -171,11 +171,11 @@
 
     "@prb/math": ["@prb/math@4.1.0", "", {}, "sha512-ef5Xrlh3BeX4xT5/Wi810dpEPq2bYPndRxgFIaKSU1F/Op/s8af03kyom+mfU7gEpvfIZ46xu8W0duiHplbBMg=="],
 
-    "@sablier/devkit": ["@sablier/devkit@github:sablier-labs/devkit#040beac", {}, "sablier-labs-devkit-040beac"],
+    "@sablier/devkit": ["@sablier/devkit@github:sablier-labs/devkit#c352301", {}, "sablier-labs-devkit-c352301"],
 
-    "@sablier/evm-utils": ["@sablier/evm-utils@github:sablier-labs/evm-utils#9b80723", { "dependencies": { "@chainlink/contracts": "1.3.0" } }, "sablier-labs-evm-utils-9b80723"],
+    "@sablier/evm-utils": ["@sablier/evm-utils@github:sablier-labs/evm-utils#6e2f629", { "dependencies": { "@chainlink/contracts": "1.3.0" } }, "sablier-labs-evm-utils-6e2f629"],
 
-    "@sablier/lockup": ["@sablier/lockup@github:sablier-labs/lockup#66d54e6", { "dependencies": { "@openzeppelin/contracts": "5.3.0", "@prb/math": "4.1.0", "@sablier/evm-utils": "github:sablier-labs/evm-utils#31f94ff" }, "peerDependencies": { "@prb/math": "4.x.x" } }, "sablier-labs-lockup-66d54e6"],
+    "@sablier/lockup": ["@sablier/lockup@github:sablier-labs/lockup#ab81e50", { "dependencies": { "@openzeppelin/contracts": "5.3.0", "@prb/math": "4.1.0", "@sablier/evm-utils": "github:sablier-labs/evm-utils" }, "peerDependencies": { "@prb/math": "4.x.x" } }, "sablier-labs-lockup-ab81e50"],
 
     "@scroll-tech/contracts": ["@scroll-tech/contracts@0.1.0", "", {}, "sha512-aBbDOc3WB/WveZdpJYcrfvMYMz7ZTEiW8M9XMJLba8p9FAR5KGYB/cV+8+EUsq3MKt7C1BfR+WnXoTVdvwIY6w=="],
 
@@ -239,7 +239,7 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
-    "bignumber.js": ["bignumber.js@9.3.0", "", {}, "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA=="],
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "blakejs": ["blakejs@1.2.1", "", {}, "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="],
 
@@ -814,8 +814,6 @@
     "@openzeppelin/upgrades-core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
-
-    "@sablier/lockup/@sablier/evm-utils": ["@sablier/evm-utils@github:sablier-labs/evm-utils#31f94ff", { "dependencies": { "@chainlink/contracts": "1.3.0" } }, "sablier-labs-evm-utils-31f94ff"],
 
     "better-ajv-errors/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/src/SablierMerkleInstant.sol
+++ b/src/SablierMerkleInstant.sol
@@ -104,6 +104,7 @@ contract SablierMerkleInstant is
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )
@@ -113,7 +114,7 @@ contract SablierMerkleInstant is
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.
-        _checkSignature(index, recipient, to, amount, signature);
+        _checkSignature(index, recipient, to, amount, validFrom, signature);
 
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);

--- a/src/SablierMerkleLL.sol
+++ b/src/SablierMerkleLL.sol
@@ -137,6 +137,7 @@ contract SablierMerkleLL is
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )
@@ -146,7 +147,7 @@ contract SablierMerkleLL is
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.
-        _checkSignature(index, recipient, to, amount, signature);
+        _checkSignature(index, recipient, to, amount, validFrom, signature);
 
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);

--- a/src/SablierMerkleLT.sol
+++ b/src/SablierMerkleLT.sol
@@ -148,6 +148,7 @@ contract SablierMerkleLT is
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )
@@ -157,7 +158,7 @@ contract SablierMerkleLT is
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.
-        _checkSignature(index, recipient, to, amount, signature);
+        _checkSignature(index, recipient, to, amount, validFrom, signature);
 
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);

--- a/src/SablierMerkleVCA.sol
+++ b/src/SablierMerkleVCA.sol
@@ -171,6 +171,7 @@ contract SablierMerkleVCA is
         address recipient,
         address to,
         uint128 fullAmount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )
@@ -180,7 +181,7 @@ contract SablierMerkleVCA is
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.
-        _checkSignature(index, recipient, to, fullAmount, signature);
+        _checkSignature(index, recipient, to, fullAmount, validFrom, signature);
 
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, fullAmount, merkleProof);

--- a/src/abstracts/SablierMerkleBase.sol
+++ b/src/abstracts/SablierMerkleBase.sol
@@ -183,13 +183,14 @@ abstract contract SablierMerkleBase is
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes calldata signature
     )
         internal
         view
     {
-        // Encode the claim parameters using claim type hash and hash it.
-        bytes32 claimHash = keccak256(abi.encode(SignatureHash.CLAIM_TYPEHASH, index, recipient, to, amount));
+        // Encode the parameters using claim type hash and hash it.
+        bytes32 claimHash = keccak256(abi.encode(SignatureHash.CLAIM_TYPEHASH, index, recipient, to, amount, validFrom));
 
         // Returns the keccak256 digest of the claim parameters using claim hash and the domain separator.
         bytes32 digest = MessageHashUtils.toTypedDataHash({ domainSeparator: DOMAIN_SEPARATOR, structHash: claimHash });
@@ -204,6 +205,11 @@ abstract contract SablierMerkleBase is
         // Check: `isSignatureValid` is true.
         if (!isSignatureValid) {
             revert Errors.SablierMerkleBase_InvalidSignature();
+        }
+
+        // Check: the `validFrom` is less than or equal to the current block timestamp.
+        if (validFrom > uint40(block.timestamp)) {
+            revert Errors.SablierMerkleBase_SignatureNotYetValid(validFrom, uint40(block.timestamp));
         }
     }
 

--- a/src/interfaces/ISablierMerkleInstant.sol
+++ b/src/interfaces/ISablierMerkleInstant.sol
@@ -62,7 +62,8 @@ interface ISablierMerkleInstant is ISablierMerkleBase {
     /// Requirements:
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
-    /// - The `to` is not the zero address.
+    /// - The `to` must not be the zero address.
+    /// - The `validFrom` must be less than or equal to the current block timestamp.
     /// - Refer to the requirements in {claim}.
     ///
     /// Below is the example of typed data to be signed by the airdrop recipient, referenced from
@@ -80,6 +81,7 @@ interface ISablierMerkleInstant is ISablierMerkleBase {
     ///     { name: "recipient", type: "address" },
     ///     { name: "to", type: "address" },
     ///     { name: "amount", type: "uint128" },
+    ///     { name: "validFrom", type: "uint40" },
     ///   ],
     /// },
     /// domain: {
@@ -92,7 +94,8 @@ interface ISablierMerkleInstant is ISablierMerkleBase {
     ///   index: 2, // The index of the signer in the Merkle tree
     ///   recipient: "0xTheAddressOfTheRecipient", // The address of the airdrop recipient
     ///   to: "0xTheAddressReceivingTheTokens", // The address where recipient wants to transfer the tokens
-    ///   amount: "1000000000000000000000" // The amount of tokens allocated to the recipient
+    ///   amount: "1000000000000000000000", // The amount of tokens allocated to the recipient
+    ///   validFrom: 1752425637 // The timestamp from which the claim signature is valid
     /// },
     /// ```
     ///
@@ -100,6 +103,7 @@ interface ISablierMerkleInstant is ISablierMerkleBase {
     /// @param recipient The address of the airdrop recipient who is providing the signature.
     /// @param to The address receiving the ERC-20 tokens on behalf of the recipient.
     /// @param amount The amount of ERC-20 tokens allocated to the recipient.
+    /// @param validFrom The timestamp from which the claim signature is valid.
     /// @param merkleProof The proof of inclusion in the Merkle tree.
     /// @param signature The EIP-712 or EIP-1271 signature from the airdrop recipient.
     function claimViaSig(
@@ -107,6 +111,7 @@ interface ISablierMerkleInstant is ISablierMerkleBase {
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )

--- a/src/interfaces/ISablierMerkleLL.sol
+++ b/src/interfaces/ISablierMerkleLL.sol
@@ -101,7 +101,8 @@ interface ISablierMerkleLL is ISablierMerkleLockup {
     /// Requirements:
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
-    /// - The `to` is not the zero address.
+    /// - The `to` must not be the zero address.
+    /// - The `validFrom` must be less than or equal to the current block timestamp.
     /// - Refer to the requirements in {claim}.
     ///
     /// Below is the example of typed data to be signed by the airdrop recipient, referenced from
@@ -119,6 +120,7 @@ interface ISablierMerkleLL is ISablierMerkleLockup {
     ///     { name: "recipient", type: "address" },
     ///     { name: "to", type: "address" },
     ///     { name: "amount", type: "uint128" },
+    ///     { name: "validFrom", type: "uint40" },
     ///   ],
     /// },
     /// domain: {
@@ -131,7 +133,8 @@ interface ISablierMerkleLL is ISablierMerkleLockup {
     ///   index: 2, // The index of the signer in the Merkle tree
     ///   recipient: "0xTheAddressOfTheRecipient", // The address of the airdrop recipient
     ///   to: "0xTheAddressReceivingTheTokens", // The address where recipient wants to transfer the tokens
-    ///   amount: "1000000000000000000000" // The amount of tokens allocated to the recipient
+    ///   amount: "1000000000000000000000", // The amount of tokens allocated to the recipient
+    ///   validFrom: 1752425637 // The timestamp from which the claim signature is valid
     /// },
     /// ```
     ///
@@ -139,6 +142,7 @@ interface ISablierMerkleLL is ISablierMerkleLockup {
     /// @param recipient The address of the airdrop recipient who is providing the signature.
     /// @param to The address to which Lockup stream or ERC-20 tokens will be sent on behalf of the recipient.
     /// @param amount The amount of ERC-20 tokens allocated to the recipient.
+    /// @param validFrom The timestamp from which the claim signature is valid.
     /// @param merkleProof The proof of inclusion in the Merkle tree.
     /// @param signature The EIP-712 or EIP-1271 signature from the airdrop recipient.
     function claimViaSig(
@@ -146,6 +150,7 @@ interface ISablierMerkleLL is ISablierMerkleLockup {
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )

--- a/src/interfaces/ISablierMerkleLT.sol
+++ b/src/interfaces/ISablierMerkleLT.sol
@@ -93,7 +93,8 @@ interface ISablierMerkleLT is ISablierMerkleLockup {
     /// Requirements:
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
-    /// - The `to` is not the zero address.
+    /// - The `to` must not be the zero address.
+    /// - The `validFrom` must be less than or equal to the current block timestamp.
     /// - Refer to the requirements in {claim}.
     ///
     /// Below is the example of typed data to be signed by the airdrop recipient, referenced from
@@ -111,6 +112,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup {
     ///     { name: "recipient", type: "address" },
     ///     { name: "to", type: "address" },
     ///     { name: "amount", type: "uint128" },
+    ///     { name: "validFrom", type: "uint40" },
     ///   ],
     /// },
     /// domain: {
@@ -123,7 +125,8 @@ interface ISablierMerkleLT is ISablierMerkleLockup {
     ///   index: 2, // The index of the signer in the Merkle tree
     ///   recipient: "0xTheAddressOfTheRecipient", // The address of the airdrop recipient
     ///   to: "0xTheAddressReceivingTheTokens", // The address where recipient wants to transfer the tokens
-    ///   amount: "1000000000000000000000" // The amount of tokens allocated to the recipient
+    ///   amount: "1000000000000000000000", // The amount of tokens allocated to the recipient
+    ///   validFrom: 1752425637 // The timestamp from which the claim signature is valid
     /// },
     /// ```
     ///
@@ -131,6 +134,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup {
     /// @param recipient The address of the airdrop recipient who is providing the signature.
     /// @param to The address to which Lockup stream or ERC-20 tokens will be sent on behalf of the recipient.
     /// @param amount The amount of ERC-20 tokens allocated to the recipient.
+    /// @param validFrom The timestamp from which the claim signature is valid.
     /// @param merkleProof The proof of inclusion in the Merkle tree.
     /// @param signature The EIP-712 or EIP-1271 signature from the airdrop recipient.
     function claimViaSig(
@@ -138,6 +142,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup {
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )

--- a/src/interfaces/ISablierMerkleVCA.sol
+++ b/src/interfaces/ISablierMerkleVCA.sol
@@ -90,6 +90,8 @@ interface ISablierMerkleVCA is ISablierMerkleBase {
     /// Requirements:
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
+    /// - The `to` must not be the zero address.
+    /// - The `validFrom` must be less than or equal to the current block timestamp.
     /// - Refer to the requirements in {claimTo} except that there are no restrictions on `msg.sender`.
     ///
     /// Below is the example of typed data to be signed by the airdrop recipient, referenced from
@@ -107,6 +109,7 @@ interface ISablierMerkleVCA is ISablierMerkleBase {
     ///     { name: "recipient", type: "address" },
     ///     { name: "to", type: "address" },
     ///     { name: "amount", type: "uint128" },
+    ///     { name: "validFrom", type: "uint40" },
     ///   ],
     /// },
     /// domain: {
@@ -119,7 +122,8 @@ interface ISablierMerkleVCA is ISablierMerkleBase {
     ///   index: 2, // The index of the signer in the Merkle tree
     ///   recipient: "0xTheAddressOfTheRecipient", // The address of the airdrop recipient
     ///   to: "0xTheAddressReceivingTheTokens", // The address where recipient wants to transfer the tokens
-    ///   amount: "1000000000000000000000" // The amount of tokens allocated to the recipient
+    ///   amount: "1000000000000000000000", // The amount of tokens allocated to the recipient
+    ///   validFrom: 1752425637 // The timestamp from which the claim signature is valid
     /// },
     /// ```
     ///
@@ -127,6 +131,7 @@ interface ISablierMerkleVCA is ISablierMerkleBase {
     /// @param recipient The address of the airdrop recipient who is providing the signature.
     /// @param to The address receiving the ERC-20 tokens on behalf of the recipient.
     /// @param fullAmount The total amount of ERC-20 tokens allocated to the recipient.
+    /// @param validFrom The timestamp from which the claim signature is valid.
     /// @param merkleProof The proof of inclusion in the Merkle tree.
     /// @param signature The EIP-712 or EIP-1271 signature from the airdrop recipient.
     function claimViaSig(
@@ -134,6 +139,7 @@ interface ISablierMerkleVCA is ISablierMerkleBase {
         address recipient,
         address to,
         uint128 fullAmount,
+        uint40 validFrom,
         bytes32[] calldata merkleProof,
         bytes calldata signature
     )

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -54,6 +54,9 @@ library Errors {
     /// @notice Thrown when trying to set a new min USD fee that is higher than the current fee.
     error SablierMerkleBase_NewMinFeeUSDNotLower(uint256 currentMinFeeUSD, uint256 newMinFeeUSD);
 
+    /// @notice Thrown when trying to claim with a signature that is not yet valid.
+    error SablierMerkleBase_SignatureNotYetValid(uint40 validFrom, uint40 blockTimestamp);
+
     /// @notice Thrown when trying to claim to the zero address.
     error SablierMerkleBase_ToZeroAddress();
 

--- a/src/libraries/SignatureHash.sol
+++ b/src/libraries/SignatureHash.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.8.22;
 library SignatureHash {
     /// @dev The struct type hash for computing the domain separator for EIP-712 and EIP-1271 signatures.
     bytes32 public constant CLAIM_TYPEHASH =
-        keccak256("Claim(uint256 index,address recipient,address to,uint128 amount)");
+        keccak256("Claim(uint256 index,address recipient,address to,uint128 amount,uint40 validFrom)");
 
     /// @notice The domain type hash for computing the domain separator.
     bytes32 public constant DOMAIN_TYPEHASH =

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -262,7 +262,15 @@ abstract contract Base_Test is Assertions, Constants, DeployOptimized, Merkle, F
             msgValue,
             abi.encodeCall(
                 ISablierMerkleInstant.claimViaSig,
-                (getIndexInMerkleTree(), users.recipient, users.eve, CLAIM_AMOUNT, getMerkleProof(), eip712Signature)
+                (
+                    getIndexInMerkleTree(),
+                    users.recipient,
+                    users.eve,
+                    CLAIM_AMOUNT,
+                    uint40(getBlockTimestamp()),
+                    getMerkleProof(),
+                    eip712Signature
+                )
             )
         );
     }

--- a/tests/integration/Integration.t.sol
+++ b/tests/integration/Integration.t.sol
@@ -92,16 +92,22 @@ abstract contract Integration_Test is Base_Test {
         ISablierMerkleInstant(campaignAddr).claimTo{ value: msgValue }(index, to, amount, merkleProof);
     }
 
-    /// @dev Claim to Eve address on behalf of `users.recipient` using {claimViaSig} function.
+    /// @dev Claim using default values for {claimViaSig} function.
     function claimViaSig() internal {
+        claimViaSig(users.recipient, CLAIM_AMOUNT);
+    }
+
+    /// @dev Claim using recipient and amount parameters for {claimViaSig} function.
+    function claimViaSig(address recipient, uint128 amount) internal {
         claimViaSig({
             msgValue: AIRDROP_MIN_FEE_WEI,
-            index: getIndexInMerkleTree(),
-            recipient: users.recipient,
+            index: getIndexInMerkleTree(recipient),
+            recipient: recipient,
             to: users.eve,
-            amount: CLAIM_AMOUNT,
-            merkleProof: getMerkleProof(),
-            signature: eip712Signature
+            amount: amount,
+            validFrom: uint40(getBlockTimestamp()),
+            merkleProof: getMerkleProof(recipient),
+            signature: generateSignature(recipient, address(merkleBase))
         });
     }
 
@@ -111,6 +117,7 @@ abstract contract Integration_Test is Base_Test {
         address recipient,
         address to,
         uint128 amount,
+        uint40 validFrom,
         bytes32[] memory merkleProof,
         bytes memory signature
     )
@@ -120,7 +127,7 @@ abstract contract Integration_Test is Base_Test {
         // claimViaSig function signature.
         address campaignAddr = address(merkleBase);
         ISablierMerkleInstant(campaignAddr).claimViaSig{ value: msgValue }(
-            index, recipient, to, amount, merkleProof, signature
+            index, recipient, to, amount, validFrom, merkleProof, signature
         );
     }
 
@@ -132,7 +139,8 @@ abstract contract Integration_Test is Base_Test {
             index: getIndexInMerkleTree(user),
             recipient: user,
             to: users.eve,
-            amount: CLAIM_AMOUNT
+            amount: CLAIM_AMOUNT,
+            validFrom: uint40(getBlockTimestamp())
         });
     }
 

--- a/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
+++ b/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
@@ -15,12 +15,13 @@ contract ClaimViaSig_MerkleInstant_Integration_Test is
         ClaimViaSig_Integration_Test.setUp();
     }
 
-    function test_WhenSignerSameAsRecipient()
+    function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
+        whenSignerSameAsRecipient
     {
         uint256 previousFeeAccrued = address(comptroller).balance;
         uint256 index = getIndexInMerkleTree();
@@ -54,15 +55,7 @@ contract ClaimViaSig_MerkleInstant_Integration_Test is
         emit ISablierMerkleInstant.ClaimInstant(index, users.smartWalletWithIERC1271, CLAIM_AMOUNT, users.eve, true);
 
         expectCallToTransfer({ to: users.eve, value: CLAIM_AMOUNT });
-        claimViaSig({
-            msgValue: AIRDROP_MIN_FEE_WEI,
-            index: index,
-            recipient: users.smartWalletWithIERC1271,
-            to: users.eve,
-            amount: CLAIM_AMOUNT,
-            merkleProof: getMerkleProof(users.smartWalletWithIERC1271),
-            signature: eip712Signature
-        });
+        claimViaSig(users.smartWalletWithIERC1271, CLAIM_AMOUNT);
 
         assertTrue(merkleInstant.hasClaimed(index), "not claimed");
 

--- a/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
+++ b/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
@@ -12,12 +12,13 @@ contract ClaimViaSig_MerkleLL_Integration_Test is ClaimViaSig_Integration_Test, 
         ClaimViaSig_Integration_Test.setUp();
     }
 
-    function test_WhenSignerSameAsRecipient()
+    function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
+        whenSignerSameAsRecipient
     {
         uint256 expectedStreamId = lockup.nextStreamId();
         uint256 previousFeeAccrued = address(comptroller).balance;
@@ -61,15 +62,7 @@ contract ClaimViaSig_MerkleLL_Integration_Test is ClaimViaSig_Integration_Test, 
         expectCallToTransferFrom({ from: address(merkleLL), to: address(lockup), value: CLAIM_AMOUNT });
 
         // Claim the airstream.
-        claimViaSig({
-            msgValue: AIRDROP_MIN_FEE_WEI,
-            index: index,
-            recipient: users.smartWalletWithIERC1271,
-            to: users.eve,
-            amount: CLAIM_AMOUNT,
-            merkleProof: getMerkleProof(users.smartWalletWithIERC1271),
-            signature: eip712Signature
-        });
+        claimViaSig(users.smartWalletWithIERC1271, CLAIM_AMOUNT);
 
         assertTrue(merkleLL.hasClaimed(index), "not claimed");
 

--- a/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
+++ b/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
@@ -12,12 +12,13 @@ contract ClaimViaSig_MerkleLT_Integration_Test is ClaimViaSig_Integration_Test, 
         ClaimViaSig_Integration_Test.setUp();
     }
 
-    function test_WhenSignerSameAsRecipient()
+    function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
+        whenSignerSameAsRecipient
     {
         uint256 expectedStreamId = lockup.nextStreamId();
         uint256 previousFeeAccrued = address(comptroller).balance;
@@ -61,15 +62,7 @@ contract ClaimViaSig_MerkleLT_Integration_Test is ClaimViaSig_Integration_Test, 
         expectCallToTransferFrom({ from: address(merkleLT), to: address(lockup), value: CLAIM_AMOUNT });
 
         // Claim the airstream.
-        claimViaSig({
-            msgValue: AIRDROP_MIN_FEE_WEI,
-            index: index,
-            recipient: users.smartWalletWithIERC1271,
-            to: users.eve,
-            amount: CLAIM_AMOUNT,
-            merkleProof: getMerkleProof(users.smartWalletWithIERC1271),
-            signature: eip712Signature
-        });
+        claimViaSig(users.smartWalletWithIERC1271, CLAIM_AMOUNT);
 
         assertTrue(merkleLT.hasClaimed(index), "not claimed");
 

--- a/tests/integration/concrete/campaign/shared/claim-via-sig/claimViaSig.tree
+++ b/tests/integration/concrete/campaign/shared/claim-via-sig/claimViaSig.tree
@@ -9,9 +9,12 @@ ClaimViaSig_Integration_Test
    │     ├── when signer different from recipient
    │     │  └── it should revert
    │     └── when signer same as recipient
-   │        ├── it should mark the index as Claimed
-   │        ├── it should transfer the ETH to the merkle lockup
-   │        └── it should emit claim event
+   │        ├── when signature validity timestamp in future
+   │        │ └── it should revert
+   │        └── when signature validity timestamp not in future
+   │          ├── it should mark the index as Claimed
+   │          ├── it should transfer the ETH to the merkle lockup
+   │          └── it should emit claim event
    └── given recipient is contract
       ├── when recipient not implement IERC1271 interface
       │  └── it should revert

--- a/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
+++ b/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
@@ -12,12 +12,13 @@ contract ClaimViaSig_MerkleVCA_Integration_Test is ClaimViaSig_Integration_Test,
         ClaimViaSig_Integration_Test.setUp();
     }
 
-    function test_WhenSignerSameAsRecipient()
+    function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
+        whenSignerSameAsRecipient
     {
         uint128 forgoneAmount = VCA_FULL_AMOUNT - VCA_CLAIM_AMOUNT;
         uint256 previousFeeAccrued = address(comptroller).balance;
@@ -69,15 +70,7 @@ contract ClaimViaSig_MerkleVCA_Integration_Test is ClaimViaSig_Integration_Test,
 
         expectCallToTransfer({ to: users.eve, value: VCA_CLAIM_AMOUNT });
 
-        claimViaSig({
-            msgValue: AIRDROP_MIN_FEE_WEI,
-            index: index,
-            recipient: users.smartWalletWithIERC1271,
-            to: users.eve,
-            amount: VCA_FULL_AMOUNT,
-            merkleProof: getMerkleProof(users.smartWalletWithIERC1271),
-            signature: eip712Signature
-        });
+        claimViaSig(users.smartWalletWithIERC1271, VCA_FULL_AMOUNT);
 
         assertTrue(merkleVCA.hasClaimed(index), "not claimed");
         assertEq(merkleVCA.totalForgoneAmount(), forgoneAmount, "total forgone amount");

--- a/tests/unit/SignatureHash.t.sol
+++ b/tests/unit/SignatureHash.t.sol
@@ -9,7 +9,8 @@ contract SignatureHash_Integration_Test is Base_Test {
     function test_Constants() external pure {
         assertEq(SignatureHash.PROTOCOL_NAME, keccak256("Sablier Airdrops Protocol"));
         assertEq(
-            SignatureHash.CLAIM_TYPEHASH, keccak256("Claim(uint256 index,address recipient,address to,uint128 amount)")
+            SignatureHash.CLAIM_TYPEHASH,
+            keccak256("Claim(uint256 index,address recipient,address to,uint128 amount,uint40 validFrom)")
         );
         assertEq(
             SignatureHash.DOMAIN_TYPEHASH,

--- a/tests/utils/Modifiers.sol
+++ b/tests/utils/Modifiers.sol
@@ -140,6 +140,10 @@ abstract contract Modifiers is EvmUtilsBase {
         _;
     }
 
+    modifier whenSignerSameAsRecipient() {
+        _;
+    }
+
     modifier whenToAddressNotZero() {
         _;
     }

--- a/tests/utils/Utilities.sol
+++ b/tests/utils/Utilities.sol
@@ -19,14 +19,15 @@ library Utilities {
         uint256 index,
         address recipient,
         address to,
-        uint128 amount
+        uint128 amount,
+        uint40 validFrom
     )
         internal
         pure
         returns (bytes memory signature)
     {
         // Compute the claim hash.
-        bytes32 claimHash = keccak256(abi.encodePacked(index, recipient, to, amount));
+        bytes32 claimHash = keccak256(abi.encodePacked(index, recipient, to, amount, validFrom));
 
         // Compute the keccak256 digest of the claim hash.
         bytes32 digest = MessageHashUtils.toEthSignedMessageHash(claimHash);
@@ -42,7 +43,8 @@ library Utilities {
         uint256 index,
         address recipient,
         address to,
-        uint128 amount
+        uint128 amount,
+        uint40 validFrom
     )
         internal
         view
@@ -52,7 +54,7 @@ library Utilities {
         bytes32 domainSeparator = computeEIP712DomainSeparator(merkleContract);
 
         // Compute the claim hash.
-        bytes32 claimHash = keccak256(abi.encode(SignatureHash.CLAIM_TYPEHASH, index, recipient, to, amount));
+        bytes32 claimHash = keccak256(abi.encode(SignatureHash.CLAIM_TYPEHASH, index, recipient, to, amount, validFrom));
 
         // Compute the keccak256 digest of the EIP-712 typed data.
         bytes32 digest = MessageHashUtils.toTypedDataHash({ domainSeparator: domainSeparator, structHash: claimHash });


### PR DESCRIPTION
Addresses [finding 16](https://cantina.xyz/code/ea8ed3af-8447-4295-83d4-f2cdc19b1c10/findings?finding=16)

As discussed, I only added `validFrom` since its important especially in the VCA campaigns.

1. I didn't add `validTo` because I don't think `validTo` will have any use case in airdrop claiming. Additionally, signature would technically stop working after the campaign expires.
2. No option to revoke signature is added since it would require us to store signature `nonce` in the storage.

If user requests for these features in the future, then we can consider it. But until then I think they are overkill for our use case.